### PR TITLE
fixed 'Wrong executable selection''

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pubspec.lock
 
 # Directory created by dartdoc
 doc/api/
+/.vs

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -133,11 +133,14 @@ class Configuration {
       throw (red(
           'Build files not found as $buildFilesFolder, first run "flutter build windows" then try again'));
 
-    executableFileName = await Directory(buildFilesFolder)
-        .list()
-        .map((file) => basename(file.path))
-        .firstWhere((fileName) => fileName.contains('.exe'),
-            orElse: () => '$appName.exe');
+    final executables = await Directory(buildFilesFolder)
+      .list()
+      .map((file) => basename(file.path))
+      .where((fileName) => fileName.contains('.exe'))
+      .toList();
+    executableFileName = executables.firstWhere(
+        (exeName) => exeName == '$appName.exe',
+        orElse: () => executables.first);
 
     if (!RegExp(r'^(\*|\d+(\.\d+){3,3}(\.\*)?)$').hasMatch(msixVersion!))
       throw (red('Msix version can be only in this format: "1.0.0.0"'));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  path: ^1.7.0
-  yaml: ^3.1.0
-  ansicolor: ^2.0.0-nullsafety.0
+  ansicolor: ^2.0.1
   args: ^2.0.0
   package_config: ^2.0.0
+  path: ^1.8.0
+  yaml: ^3.1.0


### PR DESCRIPTION
This pull request fixes the _executableFileName_ configuration value. The current algorithm assigns the value of the first executable file. íf project references several helper executables and one of them is alphabetically first (for example 7zip.exe), _executableFileName_ has the wrong value (7zip.exe in this example). 
The expected behavior is the first file corresponding to _appName_ or the first exe elsewhere.

@YehudaKremer, could you make a new preview package with this fix?