### PR TITLE
Update example versions and remove extra argument

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -16,7 +16,7 @@ msix_config:
   display_name: MyAppName
   publisher_display_name: MyName
   identity_name: MyCompany.MySuite.MyApp
-  msix_version: 2.0.2.1
+  msix_version: 2.0.2.0
   vs_generated_images_folder_path: C:\<PathToFolder>\icons
   capabilities: 'internetClient,location,microphone,webcam'
 ```
@@ -28,9 +28,8 @@ msix_config:
   publisher_display_name: MyName
   identity_name: MyCompany.MySuite.MyApp
   publisher: CN=BF212345-5644-46DF-8668-014044C1B138
-  msix_version: 1.0.0.1
+  msix_version: 1.0.0.0
   logo_path: C:\<PathToIcon>\<Logo.png>
-  store: true
   store: true
 ```
 


### PR DESCRIPTION
a) one of the examples has 'store' configured twice

b) as per [Microsoft documentation](https://docs.microsoft.com/en-us/windows/uwp/publish/package-version-numbering) the last digit of the version should be zero. 

Related to this error when submitting the application to Partner Center via API:
```
{‘code’: ‘InvalidParameterValue’, ‘details’: ’Package acceptance 
validation error: Apps are not allowed to have a Version with a revision number other than zero 
specified in the app manifest. The package shortcut_keeper.msix specifies 1.0.0.14.’}
```