### PR TITLE
include 'build windows' command into 'msix:create'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ packaging experience.
 
 This package offers a command line tool for creating MSIX installers from your
 Flutter app, making it easy to [publish your app to the Microsoft Store] or host
-it on a website. 
+it on a website.
 
 ## :clipboard: Installation
 
@@ -21,17 +21,11 @@ PS c:\src\flutter_project\> flutter pub add --dev msix
 
 ## :package: Creating an MSIX installer
 
-To create a MSIX installer from your package, run the following two commands:
+To create a MSIX installer from your package, run the following command:
 
 ```console
-PS c:\src\flutter_project\> flutter build windows
 PS c:\src\flutter_project\> flutter pub run msix:create
 ```
-
-The `flutter build windows` command compiles release executables and
-dependencies into the `build\` subdirectory. In turn, the `msix:create` command
-bundles those files along with other necessary dependencies into an MSIX install
-file.
 
 ## :gear: Configuring your installer
 
@@ -66,7 +60,7 @@ msix_config:
 | `output_path`            | `--output-path` `-o`            | The directory where the output MSIX file should be stored.            | `C:\src\myapp\msix`                           |
 | `output_name`            | `--output-name` `-n`            | The filename that should be given to the created MSIX file.           | `myApp_dev`                                   |
 | `languages`              | `--languages`                   | Declares the language resources contained in the package.             | `en-us, ja-jp`                                |
-| `capabilities`           | `--capabilities` `-e`           | List of the [capabilities][Windows capabilities] the app requires.    | `internetClient,location,microphone,webcam`   |
+| `capabilities`           | `--capabilities` `-e`           | List of the [capabilities][windows capabilities] the app requires.    | `internetClient,location,microphone,webcam`   |
 | `architecture`           | `--architecture` `-h`           | Describes the architecture of the code in the package.                | `x64`                                         |
 | `certificate_path`       | `--certificate-path` `-c`       | Path to the certificate content to place in the store.                | `C:\certs\signcert.pfx`                       |
 | `certificate_password`   | `--certificate-password` `-p`   | Password for the certificate.                                         | `1234`                                        |
@@ -86,7 +80,7 @@ that app installs and updates come from trustworthy sources.
 
 - For development purposes, this package is configured by default to
   automatically sign your app with a **test certificate**, which makes it easy
-  to test your install prior to release. 
+  to test your install prior to release.
 - If you publish your app to the **Microsoft Store**, the installation package
   will be signed automatically by the store.
 - If you need to use your **own signing certificate**, for example to release
@@ -108,25 +102,24 @@ option `dont_install_cert: true`.
 To generate an MSIX file for publishing to the Microsoft Store, use the
 `--store` flag, or alternatively add `store: true` to the YAML configuration.
 
-
 **Note**: For apps published to the Microsoft Store, the configuration values
- `publisher_display_name`, `identity_name`, `msix_version` and `publisher` must
- all be configured and should match the registered publisher and app name from
- the [Microsoft Store dashboard], as per [this screenshot].
+`publisher_display_name`, `identity_name`, `msix_version` and `publisher` must
+all be configured and should match the registered publisher and app name from
+the [Microsoft Store dashboard], as per [this screenshot].
 
 ---
 
 Tags: `msi` `windows` `win10` `win11` `windows10` `windows11` `windows store` `windows installer` `windows packaging` `appx` `AppxManifest` `SignTool` `MakeAppx`
 
-[MSIX]: https://docs.microsoft.com/en-us/windows/msix/
-[publish your app to the Microsoft Store]: https://docs.microsoft.com/en-us/windows/uwp/publish/app-submissions
+[msix]: https://docs.microsoft.com/en-us/windows/msix/
+[publish your app to the microsoft store]: https://docs.microsoft.com/en-us/windows/uwp/publish/app-submissions
 [dev dependency]: https://dart.dev/tools/pub/dependencies#dev-dependencies
-[Windows capabilities]: https://docs.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations
-[Package manifest schema reference]: https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/appxmanifestschema/schema-root
+[windows capabilities]: https://docs.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations
+[package manifest schema reference]: https://docs.microsoft.com/en-us/uwp/schemas/appxpackage/appxmanifestschema/schema-root
 [image file]: https://github.com/brendan-duncan/image#supported-image-formats
-[Protocol activation]: https://docs.microsoft.com/en-us/windows/uwp/launch-resume/handle-uri-activation
+[protocol activation]: https://docs.microsoft.com/en-us/windows/uwp/launch-resume/handle-uri-activation
 [signed with a certificate]: https://docs.microsoft.com/en-us/windows/msix/package/create-certificate-package-signing
 [signtool documentation]: https://docs.microsoft.com/en-us/dotnet/framework/tools/signtool-exe
-[Microsoft Store logo]: https://user-images.githubusercontent.com/946652/138161113-c905ec10-78f1-4d96-91ac-1295ae3d2a8c.png
-[Microsoft Store dashboard]: https://partner.microsoft.com/dashboard
+[microsoft store logo]: https://user-images.githubusercontent.com/946652/138161113-c905ec10-78f1-4d96-91ac-1295ae3d2a8c.png
+[microsoft store dashboard]: https://partner.microsoft.com/dashboard
 [this screenshot]: https://user-images.githubusercontent.com/946652/138753431-fa7dee7d-99b6-419c-94bf-4514c761abba.png

--- a/lib/msix.dart
+++ b/lib/msix.dart
@@ -1,4 +1,5 @@
 import 'package:ansicolor/ansicolor.dart' show ansiColorDisabled;
+import 'package:msix/src/windowsBuild.dart';
 import 'src/configuration.dart';
 import 'src/assets.dart';
 import 'src/makePri.dart';
@@ -32,6 +33,8 @@ class Msix {
   /// flutter pub run msix:create [cliArguments]
   Future<void> createMsix(List<String> cliArguments) async {
     await _config.getConfigValues(cliArguments);
+    await WindowsBuild(_config, _log).build();
+    await _config.validateBuildFiles();
 
     final _assets = Assets(_config, _log);
     final _signTool = SignTool(_config, _log);

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -151,20 +151,6 @@ class Configuration {
       capabilities = 'internetClient,location,microphone,webcam';
     if (languages == null) languages = ['en-us'];
 
-    if (!(await Directory(buildFilesFolder).exists())) {
-      _log.errorAndExit(BuildFilesException(
-          'Build files not found at $buildFilesFolder, first run "flutter build windows" then try again'));
-    }
-
-    executableFileName = await Directory(buildFilesFolder)
-        .list()
-        .firstWhere(
-            (file) =>
-                file.path.endsWith('.exe') &&
-                !file.path.contains('PSFLauncher64.exe'),
-            orElse: () => Directory(buildFilesFolder).listSync().first)
-        .then((file) => basename(file.path));
-
     if (!RegExp(r'^(\*|\d+(\.\d+){3,3}(\.\*)?)$').hasMatch(msixVersion!)) {
       _log.errorAndExit(VersionException(
           'Msix version can be only in this format: "1.0.0.0"'));
@@ -193,6 +179,27 @@ class Configuration {
       _log.errorAndExit(ArchitectureException(
           'Architecture can be "x86" or "x64", check "msix_config: architecture" at pubspec.yaml'));
     }
+
+    _log.taskCompleted(taskName);
+  }
+
+  Future<void> validateBuildFiles() async {
+    const taskName = 'validating build files';
+    _log.startingTask(taskName);
+
+    if (!(await Directory(buildFilesFolder).exists())) {
+      _log.errorAndExit(BuildFilesException(
+          'Build files not found at $buildFilesFolder, first run "flutter build windows" then try again'));
+    }
+
+    executableFileName = await Directory(buildFilesFolder)
+        .list()
+        .firstWhere(
+            (file) =>
+                file.path.endsWith('.exe') &&
+                !file.path.contains('PSFLauncher64.exe'),
+            orElse: () => Directory(buildFilesFolder).listSync().first)
+        .then((file) => basename(file.path));
 
     _log.taskCompleted(taskName);
   }

--- a/lib/src/log.dart
+++ b/lib/src/log.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 import 'package:ansicolor/ansicolor.dart';
 
-int numberOfAllTasks = 14;
+int numberOfAllTasks = 16;
 
 /// Handles simple logs, visual logs, colored, and errors logs
 class Log {

--- a/lib/src/signTool.dart
+++ b/lib/src/signTool.dart
@@ -19,12 +19,9 @@ class SignTool {
     const taskName = 'getting certificate publisher';
     _log.startingTask(taskName);
 
-    var certificateDetails = await Process.run('certutil', [
-      '-dump',
-      '-p',
-      _config.certificatePassword!,
-      _config.certificatePath!
-    ]);
+    var certificateDetails = await Process.run('certutil',
+        ['-dump', '-p', _config.certificatePassword!, _config.certificatePath!],
+        runInShell: true);
 
     if (certificateDetails.stderr.toString().length > 0) {
       if (certificateDetails.stderr.toString().contains('password')) {

--- a/lib/src/windowsBuild.dart
+++ b/lib/src/windowsBuild.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+import 'configuration.dart';
+import 'log.dart';
+import 'package:msix/src/extensions.dart';
+
+const runnerRcPath = 'windows/runner/Runner.rc';
+
+/// Handles windows (pre-)build steps.
+class WindowsBuild {
+  Configuration _config;
+  Log _log;
+
+  WindowsBuild(this._config, this._log);
+
+  /// Run "flutter build windows" command
+  Future<void> build() async {
+    const taskName = 'running "flutter build windows" command';
+    _log.startingTask(taskName);
+
+    await _updateRunnerCompanyName();
+
+    var result =
+        await Process.run('flutter', ['build', 'windows'], runInShell: true);
+
+    if (result.stderr.toString().length > 0) {
+      _log.error(result.stdout);
+      _log.errorAndExit(GeneralException(result.stderr));
+    } else if (result.exitCode != 0) {
+      _log.errorAndExit(GeneralException(result.stdout));
+    }
+    _log.taskCompleted(taskName);
+  }
+
+  /// Update the company name 'com.example' in the Runner.rc file
+  Future<void> _updateRunnerCompanyName() async {
+    if (_config.identityName.isNull) return;
+
+    try {
+      var runnerRcExists = await File(runnerRcPath).exists();
+      if (runnerRcExists) {
+        var runnerRcContent = await File(runnerRcPath).readAsString();
+        var runnerRcUpdatedContent =
+            runnerRcContent.replaceAll('com.example', _config.identityName!);
+        await File(runnerRcPath).writeAsString(runnerRcUpdatedContent);
+      }
+    } catch (e) {
+      _log.warn(
+          'Failed to update company name "com.example" in windows/runner/Runner.rc');
+      _log.warn(e.toString());
+    }
+  }
+}


### PR DESCRIPTION
Hello

What this branch come to solve:

Like in [Android](https://docs.flutter.dev/deployment/android#reviewing-the-app-manifest) and [ios](https://docs.flutter.dev/deployment/ios#review-xcode-project-settings) native files, the user need to update the company name "com.example.*" before testing and uploading to the store.

Windows native files have the same requirement from the user to update "company name" in the file: "windows/runner/Runner.rc" file.

One of the MSIX configuration values is the [identity_name](https://github.com/YehudaKremer/msix#gear-configuring-your-installer) which is probably the same as the "company name".

So, we can use `identity_name` value to automatically update the "windows/runner/Runner.rc" file.
this update must be before the execution of the build command `flutter build windows`,
until now the msix package didn't need to do anything before the  `flutter build windows` command and we was dependent on the user to run this command.

The changes in this branch solve this problem by doing those steps after the user run only the comment `flutter pub run msix:create`:
1. update the "company name" in the file: "windows/runner/Runner.rc" file to `identity_name`
2. executing the command `flutter build windows`
3. creating MSIX installer

output:
```console
PS C:\Users\x\Desktop\paint> flutter pub run msix:create
✓ parsing cli arguments
✓ validating config values
✓ running "flutter build windows" command
✓ validating build files
✓ cleaning temporary files
✓ creating app icons folder
✓ generating icons
✓ copying app icons
✓ copying VC libraries
✓ getting certificate publisher
✓ generate appx manifest
✓ generate package resource indexing files
✓ packing
✓ cleaning temporary files
✓ installing certificate
✓ signing
❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚ 100%
Msix Installer Created:
C:\Users\x\Desktop\paint\build\windows\runner\Release\paint.msix
```
Problem to consider:
1. the command `flutter build windows` on its own takes a long time
2. updating the "windows/runner/Runner.rc" file is unconventional