### PR TITLE
[FEATURE-UPDATE] installCert = _args || yaml, instead of  installCert = _args && yaml

### DIFF
--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -75,7 +75,7 @@ class Configuration {
     outputName = _args['output-name'] ?? yaml['output_name'];
     addExecutionAlias = _args.wasParsed('add-execution-alias') ||
         yaml['add_execution_alias']?.toLowerCase() == 'true';
-    installCert = _args['install-certificate'] != 'false' &&
+    installCert = _args['install-certificate'] != 'false' ||
         yaml['install_certificate'] != 'false';
     buildWindows = _args['build-windows'] != 'false' &&
         yaml['build_windows'].toString() != 'false';


### PR DESCRIPTION
Problem:
On remote computer like Codemagic CI/CD for Windows, terminal ask user input to proceed, 
`Do you want to install the certificate: "navoki_notes.pfx" ? (y/N) `

and `install-certificate` is not passed in command line. SignTool command is also added `signtool_options` but still ask user input in terminal
```
signtool_options: "/v /t http://timestamp.digicert.com /fd sha256 /f navoki_notes.pfx /p 123456789 build\\windows\\runner\\Release\\NavokiNotes.exe"
```

Same configuration works on local PC.

Solution
Either variable is accepted to use or skip install-certificate to make build and release on auto-pilot mode

Change
` installCert = _args['install-certificate'] != 'false' && 
        yaml['install_certificate'] != 'false';`
TO
` installCert = _args['install-certificate'] != 'false' ||
        yaml['install_certificate'] != 'false';`