### PR TITLE
Automatically use Pubspec version number as basis for MSIX version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.0
+
+- Automatically use the Pubspec `version` tag by default. To use auto-versioning, remove any `msix_version` fields or command line options.
+
 ## 3.1.6
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -128,6 +128,20 @@ msix_config:
 
 See also [Configurations Examples And Use Cases].
 
+### Version Configuration
+
+The MSIX installer version number is used to determine updates to the app and consists of 4 numbers (`1.0.0.0`). The version is determined by the first available option:
+
+1. Command line `--version` flag
+2. In `pubspec.yaml`, under the `msix_config` node, the `msix_version` value
+3. Using the `version` field in `pubspec.yaml`.
+   - The Pubspec version uses [semver], which is of the form `major.minor.patch-prerelease+build`
+   - `msix` will use the `major.minor.patch` and append a `0` for the MSIX version
+   - All prerelease and build info is discarded
+4. Fallback to `1.0.0.0`
+
+By default, if you have a valid `version` in your `pubspec.yaml` file, that will form the basis for your MSIX installer version.
+
 ## :black_nib: Signing options
 
 Published MSIX installers should be [signed with a certificate], to help ensure
@@ -227,4 +241,4 @@ Tags: `msi` `windows` `win10` `win11` `windows10` `windows11` `windows store` `w
 [disabled]: https://docs.microsoft.com/en-us/windows/msix/app-installer/installing-windows10-apps-web
 [self signed]: https://docs.microsoft.com/en-us/windows/msix/package/create-certificate-package-signing#create-a-self-signed-certificate
 [Configurations Examples And Use Cases]: https://pub.dev/packages/msix/example
-
+[semver]: https://semver.org/

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ msix_config:
   logo_path: C:\path\to\logo.png
   capabilities: internetClient, location, microphone, webcam
 ```
+See [Configurations Examples And Use Cases].
 
 ### Available Configurations
 
@@ -126,11 +127,15 @@ msix_config:
 
 </details>
 
-See also [Configurations Examples And Use Cases].
+### Msix Version
 
-### Version Configuration
+The MSIX installer version number is used to determine updates to the app and consists of 4 numbers (`1.0.0.0`).
 
-The MSIX installer version number is used to determine updates to the app and consists of 4 numbers (`1.0.0.0`). The version is determined by the first available option:
+<details>
+
+<summary>See more details on how to set the msix version (click to expand)</summary>
+
+#### The version is determined by the first available option:
 
 1. Command line `--version` flag
 2. In `pubspec.yaml`, under the `msix_config` node, the `msix_version` value
@@ -141,6 +146,8 @@ The MSIX installer version number is used to determine updates to the app and co
 4. Fallback to `1.0.0.0`
 
 By default, if you have a valid `version` in your `pubspec.yaml` file, that will form the basis for your MSIX installer version.
+
+</details>
 
 ## :black_nib: Signing options
 

--- a/example/README.md
+++ b/example/README.md
@@ -34,11 +34,16 @@ msix_config:
 ###### For CI/CD:
 
 ```yaml
+name: flutter_app
+version: 1.3.2
+
+# ...
+
 msix_config:
   display_name: Flutter App
-  msix_version: 1.0.1.0
   install_certificate: false
 ```
+Note: The main app version will be used as a basis for the MSIX version (`1.3.2` to `1.3.2.0`)
 
 ###### With Metadata:
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: msix
 description: A command-line tool that create Msix installer from your flutter windows-build files.
-version: 3.1.6
+version: 3.2.0
 maintainer: Yehuda Kremer (yehudakremer@gmail.com)
 homepage: https://github.com/YehudaKremer/msix
 

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -123,6 +123,41 @@ msix_config:
       await customConfig.getConfigValues();
       expect(config.msixVersion, isNull);
     });
+
+    test('fallback to pubspec version', () async {
+      await File(yamlTestPath).writeAsString(
+        'name: testAppWithVersion\n'
+        'version: 1.1.3',
+      );
+      await config.getConfigValues();
+      expect(config.msixVersion, equals('1.1.3.0'));
+    });
+
+    test('ignores extra semver info in pubspec version', () async {
+      await File(yamlTestPath).writeAsString(
+        'name: testAppWithVersion\n'
+        'version: 0.8.13-alpha.1+2000-01-01',
+      );
+      await config.getConfigValues();
+      expect(config.msixVersion, equals('0.8.13.0'));
+    });
+
+    test('puts version null on invalid semver', () async {
+      await File(yamlTestPath).writeAsString(
+        'name: invalidSemverApp\n'
+        'version: 0.8.13a',
+      );
+      await config.getConfigValues();
+      expect(config.msixVersion, isNull);
+    });
+
+    test('no version provided - null then maps to 1.0.0.0', () async {
+      await File(yamlTestPath).writeAsString(yamlContent);
+      await config.getConfigValues();
+      expect(config.msixVersion, isNull);
+      await config.validateConfigValues();
+      expect(config.msixVersion, equals('1.0.0.0'));
+    });
   });
 
   group('certificate:', () {


### PR DESCRIPTION
## Description
When no version is explicitly provided (either through the command line or as `msix_version` in `pubspec.yaml`), use the `version` field from `pubspec.yaml` as a basis for the MSIX version number.

This makes the default behavior more user-friendly and should simplify CI implementations for normal use.

## Breaking changes
**NO**: If the user uses specifies the version, either through `msix_version` in the YAML or through the `--version` command-line option, no changes to behavior.

**Unlikely**: If the user does not specify the version number, this will be run instead of defaulting to `1.0.0.0`. This shouldn't break any use cases, but can be worked around by explicitly specifying the version.

## Limitations
The prerelease and build parts of semver are rather unstructured, so automatically parsing them would be difficult. Instead, we're copying the `MAJOR.MINOR.PATCH` portion and adding 0 to get the MSIX version number.

## Additional
- [x] Tests
- [X] Documentation - Added as new section under configuration
- [X] Changelog + Version - Put as minor version bump

Tracking from issue: https://github.com/skyeskie/msix_config_version_match/issues/1