### PR TITLE
Call getCertificatePublisher only when publisher not set

### DIFF
--- a/lib/msix.dart
+++ b/lib/msix.dart
@@ -44,7 +44,7 @@ class Msix {
       exit(-1);
     }
 
-    if (_config.signMsix && !_config.store) {
+    if (_config.signMsix && !_config.store && _config.publisher.isNullOrEmpty) {
       await SignTool().getCertificatePublisher();
     }
     await _packMsixFiles();
@@ -111,7 +111,7 @@ class Msix {
     await assets.createIcons();
     await assets.copyVCLibsFiles();
 
-    if (_config.signMsix && !_config.store) {
+    if (_config.signMsix && !_config.store && _config.publisher.isNullOrEmpty) {
       await SignTool().getCertificatePublisher();
     }
     await AppxManifest().generateAppxManifest();


### PR DESCRIPTION
When trying to sign MSIX with a certificate from the certificate store and not from PFX file, we can achieve this by setting our own signtool_options like this:
```
msix_config:
  display_name: Flutter App
  publisher_display_name: Company Name
  identity_name: company.suite.flutterapp
  msix_version: 1.0.0.0
  logo_path: C:\path\to\logo.png
  capabilities: internetClient, location, microphone, webcam
  signtool_options: /v /fd SHA256 /a /sha1 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx /tr http://timestamp.digicert.com
  install_certificate: false
```

However when running msix:create an error will be thrown:
`Get-PfxData : The system cannot find the file specified. 0x80070002 (WIN32: 2 ERROR_FILE_NOT_FOUND)`

Turns out the code tries to get the Certificate Publisher from a PFX - not set.

This patch mitigates the issue by taking the `publisher` from the config - if it is set.

```
msix_config:
  ...
  publisher: CN=Company, O=Company,...
```

I will try to prepare an alternative patch, that will allow alternative certificate selection method