### PR TITLE
Add startup task

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ See [Configurations Examples And Use Cases].
 | `enable_at_startup`                 | `--enable-at-startup`           | App start at startup or user log-in.                                                              | `true`                                      |
 | `store`                             | `--store`                       | Generate a MSIX file for publishing to the Microsoft Store.                                       | `false`                                     |
 | [Toast Notifications configuration] |                                 |                                                                                                   |                                             |
+| [Startup Task configuration]        |                                 |                                                                                                   |                                             |
 
 </details>
 

--- a/doc/startup_task_configuration.md
+++ b/doc/startup_task_configuration.md
@@ -1,0 +1,16 @@
+## Startup Task configuration
+
+##### [Startup Task] configuration example:
+
+```yaml
+msix_config:
+  display_name: Flutter App
+  startup_task: # <-- Startup Task
+    task_id: my_flutter_app # optional (default: derived from app name)
+    enabled: true # optional (default: true)
+    parameters: autostart # optional (default: null)
+  msix_version: 1.0.3.0
+```
+
+[StartupTasks Documentation](https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-desktop-startuptasks)
+[Extension Documentation](https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-desktop-extension)

--- a/lib/src/appx_manifest.dart
+++ b/lib/src/appx_manifest.dart
@@ -87,13 +87,14 @@ class AppxManifest {
         !_config.toastActivatorCLSID.isNull ||
         (_config.appUriHandlerHosts != null &&
             _config.appUriHandlerHosts!.isNotEmpty) ||
-        _config.enableAtStartup) {
+        _config.enableAtStartup ||
+        _config.startupTask != null) {
       return '''<Extensions>
       ${!_config.executionAlias.isNull ? _getExecutionAliasExtension() : ''}
       ${_config.protocolActivation.isNotEmpty ? _getProtocolActivationExtension() : ''}
       ${!_config.fileExtension.isNull ? _getFileAssociationsExtension() : ''}
       ${!_config.toastActivatorCLSID.isNull ? _getToastNotificationActivationExtension() : ''}
-      ${_config.enableAtStartup ? _getStartupTaskExtension() : ''}
+      ${_config.enableAtStartup || _config.startupTask != null ? _getStartupTaskExtension() : ''}
       ${_config.appUriHandlerHosts != null && _config.appUriHandlerHosts!.isNotEmpty ? _getAppUriHandlerHostExtension() : ''}
         </Extensions>''';
     } else {
@@ -152,8 +153,14 @@ class AppxManifest {
   }
 
   String _getStartupTaskExtension() {
-    return '''<desktop:Extension Category="windows.startupTask" Executable="${_config.executableFileName.toHtmlEscape()}" EntryPoint="Windows.FullTrustApplication">
-      <desktop:StartupTask TaskId="${_config.appName!.replaceAll('_', '')}" Enabled="true" DisplayName="${_config.displayName.toHtmlEscape()}"/>
+    final taskId =
+        _config.startupTask?.taskId ?? _config.appName?.replaceAll('_', '');
+    final enabled = _config.startupTask?.enabled ?? true;
+    final parameters = _config.startupTask?.parameters != null
+        ? 'uap10:Parameters="${_config.startupTask?.parameters}"'
+        : '';
+    return '''<desktop:Extension Category="windows.startupTask" Executable="${_config.executableFileName.toHtmlEscape()}" EntryPoint="Windows.FullTrustApplication" $parameters>
+      <desktop:StartupTask TaskId="$taskId" Enabled="$enabled" DisplayName="${_config.displayName.toHtmlEscape()}"/>
       </desktop:Extension>''';
   }
 

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -53,6 +53,7 @@ class Configuration {
   bool trimLogo = true;
   bool createWithDebugBuildFiles = false;
   bool enableAtStartup = false;
+  StartupTask? startupTask;
   Iterable<String>? appUriHandlerHosts;
   Iterable<String>? languages;
   String get defaultsIconsFolderPath => '$msixAssetsPath/icons';
@@ -138,6 +139,11 @@ class Configuration {
     appUriHandlerHosts = _getAppUriHandlerHosts(yaml);
     enableAtStartup = _args.wasParsed('enable-at-startup') ||
         yaml['enable_at_startup']?.toString().toLowerCase() == 'true';
+
+    // A more advanced version of 'enable_at_startup'
+    startupTask = yaml['startup_task'] != null
+        ? StartupTask.fromMap(yaml['startup_task'], appName!)
+        : null;
 
     // toast activator configurations
     dynamic toastActivatorYaml = yaml['toast_activator'] ?? YamlMap();
@@ -404,4 +410,31 @@ class Configuration {
               .replaceAll(':', ''))
           .where((protocol) => protocol.isNotEmpty) ??
       [];
+}
+
+/// A more advanced version of 'enable_at_startup'.
+class StartupTask {
+  /// Identifier to enable / disable programmatically
+  final String taskId;
+
+  /// If true, then autostart is enabled by default
+  final bool enabled;
+
+  /// Parameters separated by space.
+  /// This is useful to detect if the app was started automatically.
+  final String? parameters;
+
+  StartupTask({
+    required this.taskId,
+    required this.enabled,
+    required this.parameters,
+  });
+
+  factory StartupTask.fromMap(Map map, String appName) {
+    return StartupTask(
+      taskId: map['task_id'] ?? appName.replaceAll('_', ''),
+      enabled: map['enabled'] ?? true,
+      parameters: map['parameters'],
+    );
+  }
 }


### PR DESCRIPTION
With the current `enable_at_startup` configuration, we cannot detect if the app was started automatically.
This information is essential to implement features like "start minimized" or "start hidden".

This is not a breaking change, the current `enable_at_startup` configuration should still work the same.