### PR TITLE
fix: get certificate publisher

### DIFF
--- a/lib/src/sign_tool.dart
+++ b/lib/src/sign_tool.dart
@@ -18,6 +18,11 @@ class SignTool {
   /// get the certificate "Subject" for the Publisher value
   Future<void> getCertificatePublisher() async {
     _logger.trace('getting certificate publisher');
+      
+    if (_config.publisher != null && _config.publisher!.isNotEmpty) {
+      _checkCertificateSubject(_config.publisher!);
+      return;
+    }
 
     String subject = '';
 


### PR DESCRIPTION
I encountered an Issue (same as #159) when trying to build a MSIX package with my certificate file.
 
```
building msix files...
Unhandled exception:
FormatException: Unexpected extension byte (at offset 59)
#0      _Utf8Decoder.convertChunked (dart:convert-patch/convert_patch.dart:1851:7)
#1      _Utf8ConversionSink.addSlice (dart:convert/string_conversion.dart:314:28)
#2      _Utf8ConversionSink.add (dart:convert/string_conversion.dart:310:5)
#3      _ConverterStreamEventSink.add (dart:convert/chunked_conversion.dart:72:18)
#4      _SinkTransformerStreamSubscription._handleData (dart:async/stream_transformers.dart:111:24)
#5      _RootZone.runUnaryGuarded (dart:async/zone.dart:1593:10)
#6      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
#7      _BufferingStreamSubscription._add (dart:async/stream_impl.dart:271:7)
#8      _SyncStreamControllerDispatch._sendData (dart:async/stream_controller.dart:774:19)
#10     _StreamController.add (dart:async/stream_controller.dart:596:5)
#11     _Socket._onData (dart:io-patch/socket_patch.dart:2355:41)
#12     _RootZone.runUnaryGuarded (dart:async/zone.dart:1593:10)
#13     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
#14     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:271:7)
#15     _SyncStreamControllerDispatch._sendData (dart:async/stream_controller.dart:774:19)
#16     _StreamController._add (dart:async/stream_controller.dart:648:7)
#17     _StreamController.add (dart:async/stream_controller.dart:596:5)
#18     new _RawSocket.<anonymous closure> (dart:io-patch/socket_patch.dart:1877:33)
#19     _NativeSocket.issueReadEvent.issue (dart:io-patch/socket_patch.dart:1334:14)
#20     _microtaskLoop (dart:async/schedule_microtask.dart:40:21)
#21     _startMicrotaskLoop (dart:async/schedule_microtask.dart:49:5)
#22     _runPendingImmediateCallback (dart:isolate-patch/isolate_patch.dart:123:13)
#23     _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:193:5)
pub finished with exit code 255
```
After a bit of digging through the code, i found out that it happens, when the tool tries to find the publisher subject of the certificate file (Specifically the "_getCertificateSubjectByFile" method in sign_tool.dart).

Unfortunately, I don't know how to fix the encoding problem but I found out through the documentation that you can also provide the publisher as a value in the pubspec config. This however did not completely fix my problem yet, because even if you provide this value in the config, the tool still runs into the same exception because it still tries to find the value first before using the config value as a fallback.

My proposed change is supposed to prevent the tool from attempting to find the publisher value, when it is already provided in the config.