### PR TITLE
Add `append_build_number_to_patch` config flag to append the build number to the patch number

### DIFF
--- a/doc/msix_version.md
+++ b/doc/msix_version.md
@@ -1,6 +1,6 @@
 ## MSIX Version
 
-The MSIX installer version number is used to determine updates to the app and consists of 4 numbers (`1.0.0.0`).
+The MSIX installer version number is used to determine updates to the app and consists of 4 numbers (`1.0.0.0`). 
 Using the build number as the fourth number is not allowed on the windows store ([see the important banner in the microsoft documentation](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/package-version-numbering?pivots=store-installer-msix#version-numbering-for-windows10-packages)).
 #### The version is determined by the first available option:
 

--- a/doc/msix_version.md
+++ b/doc/msix_version.md
@@ -22,7 +22,14 @@ Example:
 - Given the following value for the `version` flag: `1.2.13+35`
 - The resulting value, will be `1.2.1335.0`.
 
-
+Config Example:
+```yaml
+name: myProject
+version:1.2.3+4
+msix_config:
+  # Make sure that there is no msix_version key in this config, otherwise append_build_number_to_patch will not work
+  append_build_number_to_patch: true
+```
 
 Caveats:
 - If another version is given via the commandline (1.) or the via the `msix_version` in the `pubspec.yaml`, then the normal version tag will not be used.

--- a/doc/msix_version.md
+++ b/doc/msix_version.md
@@ -18,11 +18,14 @@ By default, if you have a valid `version` in your `pubspec.yaml` file, that will
 #### The `append_build_number_to_patch` configuration flag:
 If true, the `build`number from the `pubspec.yaml` will be appended to `patch`: `major.minor.patchbuild.0`.
 
-Example 1: 
+Example: 
 - Given the following value for the `version` flag: `1.2.13+35`
 - The resulting value, will be `1.2.1335.0`.
 
+
+
 Caveats:
+- If another version is given via the commandline (1.) or the via the `msix_version` in the `pubspec.yaml`, then the normal version tag will not be used.
 - The maximum allowed number in the version [in the windows store is 65535](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/package-version-numbering?pivots=store-installer-msix#version-numbering-for-windows10-packages). If the combined value of `build` and `patch` exceed this value, the `build` number will not be appended.
 
 To make it easy, the `build` and `patch` number should be below one of these combinations for the `build`number to be appended to the `patch`number: 

--- a/doc/msix_version.md
+++ b/doc/msix_version.md
@@ -25,7 +25,7 @@ Example 1:
 Caveats:
 - The maximum allowed number in the version [in the windows store is 65535](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/package-version-numbering?pivots=store-installer-msix#version-numbering-for-windows10-packages). If the combined value of `build` and `patch` exceed this value, the `build` number will not be appended.
 
-To make it easy, the `build` and `patch` number should be below one of these combinations: 
+To make it easy, the `build` and `patch` number should be below one of these combinations for the `build`number to be appended to the `patch`number: 
 | `patch` | `build` |
 | ------- | ------- |
 | 6       | 5535    |

--- a/doc/msix_version.md
+++ b/doc/msix_version.md
@@ -1,7 +1,7 @@
 ## MSIX Version
 
 The MSIX installer version number is used to determine updates to the app and consists of 4 numbers (`1.0.0.0`). 
-Using the build number as the fourth number is not allowed on the windows store ([see the important banner in the microsoft documentation](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/package-version-numbering?pivots=store-installer-msix#version-numbering-for-windows10-packages)).
+Using the build number as the fourth number is not allowed in the windows store ([see the important banner in the microsoft documentation](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/package-version-numbering?pivots=store-installer-msix#version-numbering-for-windows10-packages)).
 #### The version is determined by the first available option:
 
 1. Command line `--version` flag

--- a/doc/msix_version.md
+++ b/doc/msix_version.md
@@ -1,4 +1,4 @@
-## Msix Version
+## MSIX Version
 
 The MSIX installer version number is used to determine updates to the app and consists of 4 numbers (`1.0.0.0`).
 Using the build number as the fourth number is not allowed on the windows store ([see the important banner in the microsoft documentation](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/package-version-numbering?pivots=store-installer-msix#version-numbering-for-windows10-packages)).

--- a/doc/msix_version.md
+++ b/doc/msix_version.md
@@ -25,7 +25,7 @@ Example:
 Config Example:
 ```yaml
 name: myProject
-version:1.2.3+4
+version: 1.2.3+4
 msix_config:
   # Make sure that there is no msix_version key in this config, otherwise append_build_number_to_patch will not work
   append_build_number_to_patch: true

--- a/doc/msix_version.md
+++ b/doc/msix_version.md
@@ -1,7 +1,7 @@
 ## Msix Version
 
 The MSIX installer version number is used to determine updates to the app and consists of 4 numbers (`1.0.0.0`).
-Using the build number as the forth number is not allowed on the windows store ([see the important comment in the microsoft documentation](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/package-version-numbering?pivots=store-installer-msix#version-numbering-for-windows10-packages)).
+Using the build number as the fourth number is not allowed on the windows store ([see the important banner in the microsoft documentation](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/package-version-numbering?pivots=store-installer-msix#version-numbering-for-windows10-packages)).
 #### The version is determined by the first available option:
 
 1. Command line `--version` flag

--- a/doc/msix_version.md
+++ b/doc/msix_version.md
@@ -8,8 +8,8 @@ The MSIX installer version number is used to determine updates to the app and co
 2. In `pubspec.yaml`, under the `msix_config` node, the `msix_version` value
 3. Using the `version` field in `pubspec.yaml`.
    - The Pubspec version uses [semver], which is of the form `major.minor.patch-prerelease+build`
-   - `msix` will use the `major.minor.patch` and append a `0` for the MSIX version
-   - All prerelease and build info is discarded
+   - `msix` will use the `major.minor.patch.build` if `build` is an integer, otherwise `major.minor.patch.0`.
+   - All prerelease info is discarded
 4. Fallback to `1.0.0.0`
 
 By default, if you have a valid `version` in your `pubspec.yaml` file, that will form the basis for your MSIX installer version.

--- a/doc/msix_version.md
+++ b/doc/msix_version.md
@@ -1,17 +1,39 @@
 ## Msix Version
 
 The MSIX installer version number is used to determine updates to the app and consists of 4 numbers (`1.0.0.0`).
-
+Using the build number as the forth number is not allowed on the windows store ([see the important comment in the microsoft documentation](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/package-version-numbering?pivots=store-installer-msix#version-numbering-for-windows10-packages)).
 #### The version is determined by the first available option:
 
 1. Command line `--version` flag
 2. In `pubspec.yaml`, under the `msix_config` node, the `msix_version` value
 3. Using the `version` field in `pubspec.yaml`.
    - The Pubspec version uses [semver], which is of the form `major.minor.patch-prerelease+build`
-   - `msix` will use the `major.minor.patch.build` if `build` is an integer, otherwise `major.minor.patch.0`.
+   - `msix` will use the `major.minor.patch.0`.
    - All prerelease info is discarded
+   - NOTE: An additional flag can be enabled in the config called `append_build_number_to_patch`. [See below for more info](#the-append_build_number_to_patch-flag) 
 4. Fallback to `1.0.0.0`
 
 By default, if you have a valid `version` in your `pubspec.yaml` file, that will form the basis for your MSIX installer version.
 
-[semver]: https://semver.org/
+#### The `append_build_number_to_patch` configuration flag:
+If true, the `build`number from the `pubspec.yaml` will be appended to `patch`: `major.minor.patchbuild.0`.
+
+Example 1: 
+- Given the following value for the `version` flag: `1.2.13+35`
+- The resulting value, will be `1.2.1335.0`.
+
+Caveats:
+- The maximum allowed number in the version [in the windows store is 65535](https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/package-version-numbering?pivots=store-installer-msix#version-numbering-for-windows10-packages). If the combined value of `build` and `patch` exceed this value, the `build` number will not be appended.
+
+To make it easy, the `build` and `patch` number should be below one of these combinations: 
+| `patch` | `build` |
+| ------- | ------- |
+| 6       | 5535    |
+| 65      | 535     |
+| 655     | 35      |
+| 6553    | 5       |
+
+
+
+#### More info:
+[semver] : https://semver.org/

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -371,11 +371,17 @@ class Configuration {
     if (yaml['version'] == null) return null;
     try {
       final Version pubspecVersion = Version.parse(yaml['version']);
+      late final int buildNumber;
+      if (pubspecVersion.build.isNotEmpty && pubspecVersion.build[0] is int) {
+        buildNumber = pubspecVersion.build[0] as int;
+      } else {
+        buildNumber = 0;
+      }
       return [
         pubspecVersion.major,
         pubspecVersion.minor,
         pubspecVersion.patch,
-        0
+        buildNumber
       ].join('.');
     } on FormatException {
       _logger.stderr(

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -135,18 +135,54 @@ msix_config:
       await config.getConfigValues();
       expect(config.msixVersion, equals('1.2.3.0'));
     });
-    test('fallback to pubspec version', () async {
+    test('pubspec with buildnumber', () async {
       await File(yamlTestPath).writeAsString(
         'name: testAppWithVersion\n'
         'version: 1.2.3+45',
       );
       await config.getConfigValues();
-      expect(config.msixVersion, equals('1.2.3.45'));
+      expect(config.msixVersion, equals('1.2.3.0'));
     });
-    test('fallback to pubspec version', () async {
+    test('pubspec with append_build_number_to_patch false', () async {
+      await File(yamlTestPath).writeAsString('name: testAppWithVersion\n'
+          'version: 3.6.9+91\n'
+          'msix_config:\n'
+          '  append_build_number_to_patch: false');
+      print(File(yamlTestPath).readAsStringSync());
+      await config.getConfigValues();
+      expect(config.msixVersion, equals('3.6.9.0'));
+    });
+    test('pubspec with append_build_number_to_patch', () async {
+      await File(yamlTestPath).writeAsString('name: testAppWithVersion\n'
+          'version: 1.2.3+45\n'
+          'msix_config:\n'
+          '  append_build_number_to_patch: true');
+      await config.getConfigValues();
+      expect(config.msixVersion, equals('1.2.345.0'));
+    });
+    test('pubspec with max build & patch number', () async {
+      await File(yamlTestPath).writeAsString('name: testAppWithVersion\n'
+          'version: 1.2.65+535\n'
+          'msix_config:\n'
+          '  append_build_number_to_patch: true');
+      await config.getConfigValues();
+      expect(config.msixVersion, equals('1.2.65535.0'));
+    });
+    test('pubspec with max build & patch number', () async {
+      await File(yamlTestPath).writeAsString('name: testAppWithVersion\n'
+          'version: 1.2.65+536\n'
+          'msix_config:\n'
+          '  append_build_number_to_patch: true');
+      await config.getConfigValues();
+      expect(config.msixVersion, equals('1.2.65.0'));
+    });
+
+    test('pubspec with non-numeric build-number', () async {
       await File(yamlTestPath).writeAsString(
         'name: testAppWithVersion\n'
-        'version: 1.2.3+a',
+        'version: 1.2.3+a\n'
+        'msix_config:\n'
+        '  append_build_number_to_patch: true',
       );
       await config.getConfigValues();
       expect(config.msixVersion, equals('1.2.3.0'));

--- a/test/configuration_test.dart
+++ b/test/configuration_test.dart
@@ -130,12 +130,27 @@ msix_config:
     test('fallback to pubspec version', () async {
       await File(yamlTestPath).writeAsString(
         'name: testAppWithVersion\n'
-        'version: 1.1.3',
+        'version: 1.2.3',
       );
       await config.getConfigValues();
-      expect(config.msixVersion, equals('1.1.3.0'));
+      expect(config.msixVersion, equals('1.2.3.0'));
     });
-
+    test('fallback to pubspec version', () async {
+      await File(yamlTestPath).writeAsString(
+        'name: testAppWithVersion\n'
+        'version: 1.2.3+45',
+      );
+      await config.getConfigValues();
+      expect(config.msixVersion, equals('1.2.3.45'));
+    });
+    test('fallback to pubspec version', () async {
+      await File(yamlTestPath).writeAsString(
+        'name: testAppWithVersion\n'
+        'version: 1.2.3+a',
+      );
+      await config.getConfigValues();
+      expect(config.msixVersion, equals('1.2.3.0'));
+    });
     test('ignores extra semver info in pubspec version', () async {
       await File(yamlTestPath).writeAsString(
         'name: testAppWithVersion\n'


### PR DESCRIPTION
Closes #185.

- [x] Checked code
- [x] added tests
- [x] added documentation

How the flag works can be found in the documentation