### PR TITLE
feat: locate msix assets path from script file directory if necessary

### DIFF
--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -357,8 +357,19 @@ class Configuration {
       throw 'Failed to locate or read package config.';
     }
 
-    Package msixPackage =
-        packagesConfig.packages.firstWhere((package) => package.name == "msix");
+    Package? msixPackage = packagesConfig['msix'];
+
+    // Locate package config from script file directory
+    if (msixPackage == null) {
+      final scriptFile = File.fromUri(Platform.script);
+      packagesConfig = await findPackageConfig(scriptFile.parent);
+      msixPackage = packagesConfig?['msix'];
+    }
+
+    if (msixPackage == null) {
+      throw 'Failed to locate msix assets path.';
+    }
+
     String path =
         '${msixPackage.packageUriRoot.toString().replaceAll('file:///', '')}assets';
 


### PR DESCRIPTION
When I depend on `msix` in another package, the msix assets path cannot be obtained when calling `create`. I added the logic to find the package config from the directory where the script file is located.

```dart
List<String> arguments = [];
// ...
await Msix(arguments).create();
```

https://github.com/leanflutter/flutter_distributor/blob/a112f0a82cf10041f856154415dcb5e0de1d2c89/packages/flutter_app_packager/lib/src/makers/msix/app_package_maker_msix.dart#L59