### PR TITLE
sign_tool.dart: reread PSModulePath

### DIFF
--- a/lib/src/sign_tool.dart
+++ b/lib/src/sign_tool.dart
@@ -151,7 +151,7 @@ class SignTool {
         await Process.run('powershell.exe', [
       '-NoProfile',
       '-NonInteractive',
-      "dir Cert:\\CurrentUser\\Root | Where-Object { \$_.Subject -eq  '${_config.publisher}'}"
+      "\$env:PSModulePath = [Environment]::GetEnvironmentVariable('PSModulePath', 'Machine');dir Cert:\\CurrentUser\\Root | Where-Object { \$_.Subject -eq  '${_config.publisher}'}"
     ])
           ..exitOnError();
 


### PR DESCRIPTION
It fixes #181 by rereading the `PSModulePath` from the registry instead of using a possible corrupted `PSModulePath` polluted by the current environment.