### PR TITLE
Support for custom config file path 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,28 @@ To create a MSIX installer, run the following command:
 PS c:\src\flutter_project> dart run msix:create
 ```
 
+or 
+
+When using custom config file location:
+
+```console
+PS c:\src\flutter_project> dart run msix:create --config="relative/path/to/msix_config.yaml"
+```
+
+
+NOTE: If the `msix_config.yaml` is placed in the root folder, i.e., `c:\src\flutter_project\msix_config.yaml`, then giving `--config` option is not required.
+
+
+
 ## ⚙️ Configuring your installer
 
-You will almost certainly want to customize various settings in the MSIX
-installer, such as the application title, the default icon, and which [Windows
-capabilities] your application needs. You can customize the generated MSIX
-installer by adding declarations to an `msix_config:` node in your
-`pubspec.yaml` file:
+By default, the msix package will use default values to create the msix installer. But you will almost certainly want to customize various settings in the MSIX installer, such as the application title, the default icon, and which [Windows capabilities] your application needs. 
+
+You can customize the generated MSIX installer by adding declarations to an `msix_config:` node in your `pubspec.yaml` file 
+
+or 
+
+by creating a separate `msix_config.yaml` file in your project. The config file can be created at the root of the project or in a separate folder.
 
 ```yaml
 msix_config:
@@ -51,6 +66,8 @@ msix_config:
   logo_path: C:\path\to\logo.png
   capabilities: internetClient, location, microphone, webcam
 ```
+
+
 
 See [Configurations Examples And Use Cases].
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,17 @@ When using custom config file location:
 PS c:\src\flutter_project> dart run msix:create --config="relative/path/to/msix_config.yaml"
 ```
 
-
 NOTE: If the `msix_config.yaml` is placed in the root folder, i.e., `c:\src\flutter_project\msix_config.yaml`, then giving `--config` option is not required.
 
+or
+
+When using custom config node for providing build arguments using `--dart-define`:
+
+```console
+PS c:\src\flutter_project> dart run msix:create --flavour="development-sql"
+```
+
+NOTE: Please check out below section on how to create a custom `msix_config` node.
 
 
 ## ⚙️ Configuring your installer
@@ -67,6 +75,19 @@ msix_config:
   capabilities: internetClient, location, microphone, webcam
 ```
 
+If you want to customise your msix builds as per `windows_build_args:` such as defining `--dart-define="FLAVOUR=production"` or any other custom variable in the build command, you can provide a very custom config based on such definition value. So the production config will become `msix_config-production`. 
+
+```yaml
+msix_config-production:
+  windows_build_args: --dart-define="FLAVOUR=production"
+```
+
+For multiple `--dart-define` values, you can concatenate each definition value by `-`. Example: 
+
+```yaml
+msix_config-develpment-sql:
+  windows_build_args: --dart-define="FLAVOUR=production" --dart-define="DATABASE=sql"
+```
 
 
 See [Configurations Examples And Use Cases].


### PR DESCRIPTION
- Added the option to let users place `msix_config.yaml` as a separate file and pass it as an option when creating a msix installer.
- Improved readme regarding new option

Closes https://github.com/YehudaKremer/msix/issues/220