### PR TITLE
Update appx_manifest.dart

### DIFF
--- a/lib/src/appx_manifest.dart
+++ b/lib/src/appx_manifest.dart
@@ -50,6 +50,7 @@ class AppxManifest {
       ${_config.languages!.map((language) => '<Resource Language="$language" />').join('')}
     </Resources>
     <Dependencies>
+      <TargetDeviceFamily Name="MSIXCore.Desktop" MinVersion="${_config.osMinVersion}" MaxVersionTested="10.0.22621.1778" />
       <TargetDeviceFamily Name="Windows.Desktop" MinVersion="${_config.osMinVersion}" MaxVersionTested="10.0.22621.1778" />
     </Dependencies>
     <Capabilities>


### PR DESCRIPTION
Allows installer to use msix core on older versions of windows

MSIX Core allows msix files to be installed on older versions of windows and Enterprise versions that don't support them yet.  Adding this line in will let this work without any custom effort.  Tested against Windows 10 Enterprise.