### PR TITLE
Add option for Microsoft Webview dependency

### DIFF
--- a/lib/src/appx_manifest.dart
+++ b/lib/src/appx_manifest.dart
@@ -37,7 +37,8 @@ class AppxManifest {
           xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10" 
           xmlns:com2="http://schemas.microsoft.com/appx/manifest/com/windows10/2" 
           xmlns:com3="http://schemas.microsoft.com/appx/manifest/com/windows10/3" 
-          IgnorableNamespaces="uap3 desktop">
+          xmlns:win32dependencies="http://schemas.microsoft.com/appx/manifest/externaldependencies" 
+          IgnorableNamespaces="uap3 desktop win32dependencies">
     <Identity Name="${_config.identityName}" Version="${_config.msixVersion}"
               Publisher="${_config.publisher!.replaceAll(' = ', '=').toHtmlEscape()}" ProcessorArchitecture="${_config.architecture}" />
     <Properties>
@@ -51,6 +52,7 @@ class AppxManifest {
     </Resources>
     <Dependencies>
       <TargetDeviceFamily Name="Windows.Desktop" MinVersion="${_config.osMinVersion}" MaxVersionTested="10.0.22621.2506" />
+      ${_config.addWebViewDependency ? '<win32dependencies:ExternalDependency Name="Microsoft.WebView2" MinVersion="1.1.1.1" Publisher="CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Optional="false"/>' : ''}
     </Dependencies>
     <Capabilities>
       ${_getCapabilities()}

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -52,6 +52,7 @@ class Configuration {
   bool store = false;
   bool signMsix = true;
   bool installCert = true;
+  bool addWebViewDependency = false;
   bool buildWindows = true;
   bool trimLogo = true;
   bool createWithDebugBuildFiles = false;
@@ -89,6 +90,10 @@ class Configuration {
     outputPath = _args['output-path'] ?? yaml['output_path'];
     outputName = _args['output-name'] ?? yaml['output_name'];
     executionAlias = _args['execution-alias'] ?? yaml['execution_alias'];
+    if (_args['add-webview-dependency'].toString() == 'true' ||
+        yaml['add_webview_dependency']?.toString().toLowerCase() == 'true') {
+      addWebViewDependency = true;
+    }
     if (_args['sign-msix'].toString() == 'false' ||
         yaml['sign_msix']?.toString().toLowerCase() == 'false') {
       signMsix = false;
@@ -415,7 +420,8 @@ class Configuration {
       ..addFlag('update-blocks-activation')
       ..addFlag('show-prompt')
       ..addFlag('force-update-from-any-version')
-      ..addFlag('skip-context-menu');
+      ..addFlag('skip-context-menu')
+      ..addFlag('add-webview-dependency');
 
     // exclude -v (verbose) from the arguments
     _args = parser.parse(args.where((arg) => arg != '-v'));


### PR DESCRIPTION
This pull request adds an option for adding the Microsoft Webview dependency to the generated msix file. 
The Microsoft Webview dependency is required when using packages such as: [desktop_webview_window](https://github.com/MixinNetwork/flutter-plugins/tree/main/packages/desktop_webview_window)