### PR TITLE
fix #287 and add override-executable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See [Configurations Examples And Use Cases].
 <summary>MSIX configuration (click to expand)</summary>
 
 | YAML name                           | Command-line argument           | Description (from Microsoft [Package manifest schema reference])                                  | Example                                     |
-| ----------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------- |
+| ----------------------------------- | ------------------------------- |---------------------------------------------------------------------------------------------------|---------------------------------------------|
 | `display_name`                      | `--display-name` `-d`           | A friendly app name that can be displayed to users.                                               | `Flutter App`                               |
 | `publisher_display_name`            | `--publisher-display-name` `-u` | A friendly name for the publisher that can be displayed to users.                                 | `Company Name`                              |
 | `identity_name`                     | `--identity-name` `-i`          | Defines the unique identifier for the app.                                                        | `company.suite.flutterapp`                  |
@@ -74,6 +74,7 @@ See [Configurations Examples And Use Cases].
 | `protocol_activation`               | `--protocol-activation`         | [Protocols activation] that will activate the app.                                                | `http,https`                                |
 | `app_uri_handler_hosts`             | `--app-uri-handler-hosts`       | Enable [apps for websites] using app URI handlers app.                                            | `test.com, test2.info`                      |
 | `execution_alias`                   | `--execution-alias`             | [Execution alias] command (cmd) that will activate the app.                                       | `myapp`                                     |
+| `override_executable`               | `--override-executable`         | Overrides file name of the startup executable.                                                    | `myapp.exe`                                 |
 | `enable_at_startup`                 | `--enable-at-startup`           | App start at startup or user log-in.                                                              | `true`                                      |
 | `store`                             | `--store`                       | Generate a MSIX file for publishing to the Microsoft Store.                                       | `false`                                     |
 | `os_min_version`                    | `--os-min-version`              | Set minimum OS version, default is `10.0.17763.0`                                                 | `10.0.17763.0`                              |


### PR DESCRIPTION
This PR fixes #287 and adds an option to specify the executable, so that users have the ability to manually set the executable name, enabling them to mitigate future issues with the automatic selection of the executable file name.