### PR TITLE
Added Msix.assetUri() to get an `ms-appx:///` URI of Flutter assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.17.0
+
+- Add `Msix.assetUri()` to get an `ms-appx:///` URI out of any Flutter asset name.
+
 ## 3.16.8
 
 - update VCLibs files [#273](https://github.com/YehudaKremer/msix/pull/273)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In your `pubspec.yaml`, add the `msix` package as a new [dev dependency] with
 the following command:
 
 ```console
-PS c:\src\flutter_project> flutter pub add --dev msix
+PS c:\src\flutter_project> flutter pub add msix
 ```
 
 ## 📦 Creating an MSIX installer

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ it on a website.
 
 ## 📋 Installation
 
-In your `pubspec.yaml`, add the `msix` package as a new [dev dependency] with
+In your `pubspec.yaml`, add the `msix` package as a new dependency with
 the following command:
 
 ```console
-PS c:\src\flutter_project> flutter pub add msix
+PS c:\src\flutter_project> dart pub add msix
 ```
 
 ## 📦 Creating an MSIX installer

--- a/README.md
+++ b/README.md
@@ -135,6 +135,21 @@ the `certificate_path` and `certificate_password` fields.
 machine. You can disable this by using the `--install-certificate false` option, or the YAML
 option `install_certificate: false`.
 
+## Using Assets
+
+If you need to get an `ms-appx:///` URI from a Flutter asset, use `Msix.assetUrI()`:
+
+```dart
+// Flutter
+final logoPath = 'assets/logo.png';
+Image.asset(logoPath);
+
+// Windows APIs
+final logoUri = Msix.assetUri('assets/logo.png');
+someWindowsApi(logoUri);
+```
+
+
 ## ![microsoft store icon][] Publishing to the Microsoft Store
 
 To generate an MSIX file for publishing to the Microsoft Store, use the

--- a/lib/msix.dart
+++ b/lib/msix.dart
@@ -14,6 +14,8 @@ import 'src/method_extensions.dart';
 
 /// Main class that handles all the msix package functionality
 class Msix {
+  static Uri assetUri(String path) => Uri.parse("ms-appx:///data/flutter_assets/$path");
+
   late Logger _logger;
   late Configuration _config;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: msix
 description: A command-line tool that create Msix installer from your flutter windows-build files.
-version: 3.16.8
+version: 3.17.0
 maintainer: Yehuda Kremer (yehudakremer@gmail.com)
 homepage: https://github.com/YehudaKremer/msix
 issue_tracker: https://github.com/YehudaKremer/msix/issues

--- a/test/misc_test.dart
+++ b/test/misc_test.dart
@@ -1,0 +1,10 @@
+import 'package:msix/msix.dart';
+import 'package:test/test.dart';
+
+void main() => test(
+  'Asset URIs are valid',
+  () => expect(
+    Msix.assetUri('assets/image.jpg'),
+    Uri.parse('ms-appx:///data/flutter_assets/assets/image.jpg'),
+  ),
+);


### PR DESCRIPTION
- Adds `Uri Msix.assetUri(String)`
- Adds section to the README on how to get ms-appx URIs for Flutter assets
  - Since users may now be importing `package:msix`, I removed the recommendation to use a `--dev` dependency
- Adds test to make sure the new function works as expected
- Bumps pubspec version and updates changelog (minor version)