### PR TITLE
Added `Msix.hasPackageIdentity()` to check if an app was installed with an MSIX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.17.0
+
+- Add `Msix.assetUri()` to get an `ms-appx:///` URI out of any Flutter asset name.
+
 ## 3.16.8
 
 - update VCLibs files [#273](https://github.com/YehudaKremer/msix/pull/273)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.17.0
 
 - Add `Msix.assetUri()` to get an `ms-appx:///` URI out of any Flutter asset name.
+- Add `Msix.hasPackageIdentity()` to check if the currently running program was installed with an MSIX.
 
 ## 3.16.8
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ the `certificate_path` and `certificate_password` fields.
 machine. You can disable this by using the `--install-certificate false` option, or the YAML
 option `install_certificate: false`.
 
-## Using Assets
+## Using this package at runtime
+
+### Get a URI to Flutter assets
 
 If you need to get an `ms-appx:///` URI from a Flutter asset, use `Msix.assetUrI()`:
 
@@ -149,6 +151,15 @@ final logoUri = Msix.assetUri('assets/logo.png');
 someWindowsApi(logoUri);
 ```
 
+### Check if an app was installed with an MSIX
+
+Using an MSIX grants your application [package identity](https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/package-identity-overview), which, among other things, allows it to use [certain APIs](https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/modernize-packaged-apps). You might need to check at runtime if your application has package identity.
+
+```dart
+if (Msix.hasPackageIdentity()) {
+  showNotifications();
+}
+```
 
 ## ![microsoft store icon][] Publishing to the Microsoft Store
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In your `pubspec.yaml`, add the `msix` package as a new [dev dependency] with
 the following command:
 
 ```console
-PS c:\src\flutter_project> flutter pub add --dev msix
+PS c:\src\flutter_project> flutter pub add msix
 ```
 
 ## 📦 Creating an MSIX installer

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ it on a website.
 
 ## 📋 Installation
 
-In your `pubspec.yaml`, add the `msix` package as a new [dev dependency] with
+In your `pubspec.yaml`, add the `msix` package as a new dependency with
 the following command:
 
 ```console
-PS c:\src\flutter_project> flutter pub add msix
+PS c:\src\flutter_project> dart pub add msix
 ```
 
 ## 📦 Creating an MSIX installer

--- a/README.md
+++ b/README.md
@@ -135,6 +135,21 @@ the `certificate_path` and `certificate_password` fields.
 machine. You can disable this by using the `--install-certificate false` option, or the YAML
 option `install_certificate: false`.
 
+## Using Assets
+
+If you need to get an `ms-appx:///` URI from a Flutter asset, use `Msix.assetUrI()`:
+
+```dart
+// Flutter
+final logoPath = 'assets/logo.png';
+Image.asset(logoPath);
+
+// Windows APIs
+final logoUri = Msix.assetUri('assets/logo.png');
+someWindowsApi(logoUri);
+```
+
+
 ## ![microsoft store icon][] Publishing to the Microsoft Store
 
 To generate an MSIX file for publishing to the Microsoft Store, use the

--- a/lib/msix.dart
+++ b/lib/msix.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:cli_util/cli_logging.dart';
 import 'package:get_it/get_it.dart';
+
 import 'src/app_installer.dart';
 import 'src/windows_build.dart';
 import 'src/configuration.dart';
@@ -11,11 +12,16 @@ import 'src/appx_manifest.dart';
 import 'src/makeappx.dart';
 import 'src/sign_tool.dart';
 import 'src/method_extensions.dart';
+import 'src/msix_check.dart';
 
 /// Main class that handles all the msix package functionality
 class Msix {
   /// Gets an `ms-appx:///` URI from a [Flutter asset](https://docs.flutter.dev/ui/assets/assets-and-images).
   static Uri assetUri(String path) => Uri.parse("ms-appx:///data/flutter_assets/$path");
+
+  static bool hasPackageIdentity() {
+    return checkPackageIdentity();
+  }
 
   late Logger _logger;
   late Configuration _config;

--- a/lib/msix.dart
+++ b/lib/msix.dart
@@ -14,6 +14,7 @@ import 'src/method_extensions.dart';
 
 /// Main class that handles all the msix package functionality
 class Msix {
+  /// Gets an `ms-appx:///` URI from a [Flutter asset](https://docs.flutter.dev/ui/assets/assets-and-images).
   static Uri assetUri(String path) => Uri.parse("ms-appx:///data/flutter_assets/$path");
 
   late Logger _logger;

--- a/lib/msix.dart
+++ b/lib/msix.dart
@@ -14,6 +14,8 @@ import 'src/method_extensions.dart';
 
 /// Main class that handles all the msix package functionality
 class Msix {
+  static Uri assetUri(String path) => Uri.parse("ms-appx:///data/flutter_assets/$path");
+
   late Logger _logger;
   late Configuration _config;
 

--- a/lib/msix.dart
+++ b/lib/msix.dart
@@ -19,6 +19,10 @@ class Msix {
   /// Gets an `ms-appx:///` URI from a [Flutter asset](https://docs.flutter.dev/ui/assets/assets-and-images).
   static Uri assetUri(String path) => Uri.parse("ms-appx:///data/flutter_assets/$path");
 
+  /// Returns whether the current app was installed with an MSIX installer.
+  ///
+  /// Using an MSIX grants your application [package identity](https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/package-identity-overview),
+  /// which allows it to use [certain APIs](https://learn.microsoft.com/en-us/windows/apps/desktop/modernize/modernize-packaged-apps).
   static bool hasPackageIdentity() {
     return checkPackageIdentity();
   }

--- a/lib/src/msix_check.dart
+++ b/lib/src/msix_check.dart
@@ -1,2 +1,2 @@
 export 'msix_check/stub.dart'
-  if (dart.library.ffi) 'msix_check/io.dart';
+  if (dart.library.ffi) 'msix_check/ffi.dart';

--- a/lib/src/msix_check.dart
+++ b/lib/src/msix_check.dart
@@ -1,0 +1,2 @@
+export 'msix_check/stub.dart'
+  if (dart.library.ffi) 'msix_check/io.dart';

--- a/lib/src/msix_check/ffi.dart
+++ b/lib/src/msix_check/ffi.dart
@@ -3,29 +3,12 @@ import "dart:ffi";
 import "package:ffi/ffi.dart";
 import "package:win32/win32.dart";
 
-const win8Version = 0x0602;
-
-bool isWindows8OrGreater() => IsWindowsVersionOrGreater(
-  HIBYTE(win8Version),
-  LOBYTE(win8Version),
-  0,
-) == 1;
-
-typedef NativeGetPackageName = Uint32 Function(Pointer<Uint32>, Pointer<Utf16>);
-typedef DartGetPackageName = int Function(Pointer<Uint32>, Pointer<Utf16>);
-
-extension on DynamicLibrary {
-  int getCurrentPackageName(Pointer<Uint32> length, Pointer<Utf16> buffer) =>
-    lookupFunction<NativeGetPackageName, DartGetPackageName>('GetCurrentPackageFullName')(length, buffer);
-}
+bool isWindows8OrGreater() => IsWindows8OrGreater() == 1;
 
 bool checkPackageIdentity() => using((arena) {
   if (!Platform.isWindows) return false;
   if (!isWindows8OrGreater()) return false;
-  final lib = DynamicLibrary.open('kernel32.dll');
   final length = arena<Uint32>();
-  final error = lib.getCurrentPackageName(length, nullptr);
-  final result = error != WIN32_ERROR.APPMODEL_ERROR_NO_PACKAGE;
-  lib.close();
-  return result;
+  final error = GetCurrentPackageFullName(length, nullptr);
+  return error != WIN32_ERROR.APPMODEL_ERROR_NO_PACKAGE;
 });

--- a/lib/src/msix_check/ffi.dart
+++ b/lib/src/msix_check/ffi.dart
@@ -1,0 +1,31 @@
+import "dart:io";
+import "dart:ffi";
+import "package:ffi/ffi.dart";
+import "package:win32/win32.dart";
+
+const win8Version = 0x0602;
+
+bool isWindows8OrGreater() => IsWindowsVersionOrGreater(
+  HIBYTE(win8Version),
+  LOBYTE(win8Version),
+  0,
+) == 1;
+
+typedef NativeGetPackageName = Uint32 Function(Pointer<Uint32>, Pointer<Utf16>);
+typedef DartGetPackageName = int Function(Pointer<Uint32>, Pointer<Utf16>);
+
+extension on DynamicLibrary {
+  int getCurrentPackageName(Pointer<Uint32> length, Pointer<Utf16> buffer) =>
+    lookupFunction<NativeGetPackageName, DartGetPackageName>('GetCurrentPackageFullName')(length, buffer);
+}
+
+bool checkPackageIdentity() => using((arena) {
+  if (!Platform.isWindows) return false;
+  if (!isWindows8OrGreater()) return false;
+  final lib = DynamicLibrary.open('kernel32.dll');
+  final length = arena<Uint32>();
+  final error = lib.getCurrentPackageName(length, nullptr);
+  final result = error != WIN32_ERROR.APPMODEL_ERROR_NO_PACKAGE;
+  lib.close();
+  return result;
+});

--- a/lib/src/msix_check/stub.dart
+++ b/lib/src/msix_check/stub.dart
@@ -1,0 +1,1 @@
+bool checkPackageIdentity() => false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dependencies:
   console: ^4.1.0
   cli_util: ^0.4.0
   ffi: ^2.1.3
-  win32: ^5.9.0
+  win32: ^5.10.0
 
 dev_dependencies:
   test: ^1.23.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ platforms:
   windows:
 
 environment:
-  sdk: ">=2.19.0 <4.0.0"
+  sdk: ">=3.1.0 <4.0.0"
 
 dependencies:
   args: ^2.3.0
@@ -27,6 +27,8 @@ dependencies:
   pub_semver: ^2.1.0
   console: ^4.1.0
   cli_util: ^0.4.0
+  ffi: ^2.1.3
+  win32: ^5.9.0
 
 dev_dependencies:
   test: ^1.23.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: msix
 description: A command-line tool that create Msix installer from your flutter windows-build files.
-version: 3.16.8
+version: 3.17.0
 maintainer: Yehuda Kremer (yehudakremer@gmail.com)
 homepage: https://github.com/YehudaKremer/msix
 issue_tracker: https://github.com/YehudaKremer/msix/issues

--- a/test/misc_test.dart
+++ b/test/misc_test.dart
@@ -1,0 +1,10 @@
+import 'package:msix/msix.dart';
+import 'package:test/test.dart';
+
+void main() => test(
+  'Asset URIs are valid',
+  () => expect(
+    Msix.assetUri('assets/image.jpg'),
+    Uri.parse('ms-appx:///data/flutter_assets/assets/image.jpg'),
+  ),
+);


### PR DESCRIPTION
Has some commits from #293 so please merge that first or merge this instead. Has some code that might be merged into `package:win32`, see https://github.com/halildurmus/win32/issues/943. Tested, and it works: 

![image](https://github.com/user-attachments/assets/3fe48460-f3f1-4215-859f-c37e2de120d2)

Closes #292 