### PR TITLE
crashpad_handler.exe  - discover the name of the exe without put wrong exe in AppxManifest.xml

### DIFF
--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -1,13 +1,15 @@
 import 'dart:io';
-import 'package:msix/src/context_menu_configuration.dart';
-import 'package:path/path.dart' as p;
+
 import 'package:args/args.dart';
 import 'package:cli_util/cli_logging.dart';
 import 'package:get_it/get_it.dart';
+import 'package:msix/src/context_menu_configuration.dart';
 import 'package:package_config/package_config.dart';
+import 'package:path/path.dart' as p;
 import 'package:path/path.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
+
 import 'command_line_converter.dart';
 import 'method_extensions.dart';
 import 'sign_tool.dart';
@@ -23,8 +25,7 @@ class Configuration {
   String? identityName;
   String? msixVersion;
   String? appDescription;
-  String buildFilesFolder =
-      p.join(Directory.current.path, 'build', 'windows', 'runner', 'Release');
+  String buildFilesFolder = p.join(Directory.current.path, 'build', 'windows', 'runner', 'Release');
   String? certificatePath;
   String? certificatePassword;
   String? publisher;
@@ -60,12 +61,9 @@ class Configuration {
   Iterable<String>? appUriHandlerHosts;
   Iterable<String>? languages;
   String get defaultsIconsFolderPath => p.join(msixAssetsPath, 'icons');
-  String get msixToolkitPath =>
-      p.join(msixAssetsPath, 'MSIX-Toolkit', 'Redist.x64');
-  String get msixPath =>
-      p.join(outputPath ?? buildFilesFolder, '${outputName ?? appName}.msix');
-  String get appInstallerPath => p.join(publishFolderPath!,
-      basename(msixPath).replaceAll('.msix', '.appinstaller'));
+  String get msixToolkitPath => p.join(msixAssetsPath, 'MSIX-Toolkit', 'Redist.x64');
+  String get msixPath => p.join(outputPath ?? buildFilesFolder, '${outputName ?? appName}.msix');
+  String get appInstallerPath => p.join(publishFolderPath!, basename(msixPath).replaceAll('.msix', '.appinstaller'));
   String pubspecYamlPath = "pubspec.yaml";
   String osMinVersion = '10.0.17763.0';
   bool isTestCertificate = false;
@@ -81,53 +79,41 @@ class Configuration {
     appName = pubspec['name'];
     appDescription = pubspec['description'];
     dynamic yaml = pubspec['msix_config'] ?? YamlMap();
-    msixVersion =
-        _args['version'] ?? yaml['msix_version'] ?? _getPubspecVersion(pubspec);
+    msixVersion = _args['version'] ?? yaml['msix_version'] ?? _getPubspecVersion(pubspec);
     certificatePath = _args['certificate-path'] ?? yaml['certificate_path'];
-    certificatePassword = _args['certificate-password'] ??
-        yaml['certificate_password']?.toString();
+    certificatePassword = _args['certificate-password'] ?? yaml['certificate_password']?.toString();
     outputPath = _args['output-path'] ?? yaml['output_path'];
     outputName = _args['output-name'] ?? yaml['output_name'];
     executionAlias = _args['execution-alias'] ?? yaml['execution_alias'];
-    if (_args['sign-msix'].toString() == 'false' ||
-        yaml['sign_msix']?.toString().toLowerCase() == 'false') {
+    if (_args['sign-msix'].toString() == 'false' || yaml['sign_msix']?.toString().toLowerCase() == 'false') {
       signMsix = false;
     }
-    if (_args['install-certificate'].toString() == 'false' ||
-        yaml['install_certificate']?.toString().toLowerCase() == 'false') {
+    if (_args['install-certificate'].toString() == 'false' || yaml['install_certificate']?.toString().toLowerCase() == 'false') {
       installCert = false;
     }
-    if (_args['build-windows'].toString() == 'false' ||
-        yaml['build_windows']?.toString().toLowerCase() == 'false') {
+    if (_args['build-windows'].toString() == 'false' || yaml['build_windows']?.toString().toLowerCase() == 'false') {
       buildWindows = false;
     }
-    if (_args['trim-logo'].toString() == 'false' ||
-        yaml['trim_logo']?.toString().toLowerCase() == 'false') {
+    if (_args['trim-logo'].toString() == 'false' || yaml['trim_logo']?.toString().toLowerCase() == 'false') {
       trimLogo = false;
     }
-    store = _args.wasParsed('store') ||
-        yaml['store']?.toString().toLowerCase() == 'true';
-    createWithDebugBuildFiles = _args.wasParsed('debug') ||
-        yaml['debug']?.toString().toLowerCase() == 'true';
+    store = _args.wasParsed('store') || yaml['store']?.toString().toLowerCase() == 'true';
+    createWithDebugBuildFiles = _args.wasParsed('debug') || yaml['debug']?.toString().toLowerCase() == 'true';
 
     displayName = _args['display-name'] ?? yaml['display_name'];
-    publisherName =
-        _args['publisher-display-name'] ?? yaml['publisher_display_name'];
+    publisherName = _args['publisher-display-name'] ?? yaml['publisher_display_name'];
     publisher = _args['publisher'] ?? yaml['publisher'];
     identityName = _args['identity-name'] ?? yaml['identity_name'];
     logoPath = _args['logo-path'] ?? yaml['logo_path'];
-    osMinVersion =
-        _args['os-min-version'] ?? yaml['os_min_version'] ?? osMinVersion;
+    osMinVersion = _args['os-min-version'] ?? yaml['os_min_version'] ?? osMinVersion;
 
-    final String? signToolOptionsConfig =
-        (_args['signtool-options'] ?? yaml['signtool_options'])?.toString();
+    final String? signToolOptionsConfig = (_args['signtool-options'] ?? yaml['signtool_options'])?.toString();
     if (signToolOptionsConfig != null && signToolOptionsConfig.isNotEmpty) {
       CommandLineConverter commandLineConverter = CommandLineConverter();
       signToolOptions = commandLineConverter.convert(signToolOptionsConfig);
     }
 
-    final String? windowsBuildArgsConfig =
-        (_args['windows-build-args'] ?? yaml['windows_build_args'])?.toString();
+    final String? windowsBuildArgsConfig = (_args['windows-build-args'] ?? yaml['windows_build_args'])?.toString();
     if (windowsBuildArgsConfig != null && windowsBuildArgsConfig.isNotEmpty) {
       CommandLineConverter commandLineConverter = CommandLineConverter();
       windowsBuildArgs = commandLineConverter.convert(windowsBuildArgsConfig);
@@ -143,60 +129,35 @@ class Configuration {
     capabilities = _args['capabilities'] ?? yaml['capabilities'];
     languages = _getLanguages(yaml);
     appUriHandlerHosts = _getAppUriHandlerHosts(yaml);
-    enableAtStartup = _args.wasParsed('enable-at-startup') ||
-        yaml['enable_at_startup']?.toString().toLowerCase() == 'true';
+    enableAtStartup = _args.wasParsed('enable-at-startup') || yaml['enable_at_startup']?.toString().toLowerCase() == 'true';
 
     // A more advanced version of 'enable_at_startup'
-    startupTask = yaml['startup_task'] != null
-        ? StartupTask.fromMap(yaml['startup_task'], appName!)
-        : null;
+    startupTask = yaml['startup_task'] != null ? StartupTask.fromMap(yaml['startup_task'], appName!) : null;
 
     // toast activator configurations
     dynamic toastActivatorYaml = yaml['toast_activator'] ?? YamlMap();
 
-    toastActivatorCLSID = _args['toast-activator-clsid'] ??
-        toastActivatorYaml['clsid']?.toString();
-    toastActivatorArguments = _args['toast-activator-arguments'] ??
-        toastActivatorYaml['arguments']?.toString() ??
-        '----AppNotificationActivationServer';
-    toastActivatorDisplayName = _args['toast-activator-display-name'] ??
-        toastActivatorYaml['display_name']?.toString() ??
-        'Toast activator';
+    toastActivatorCLSID = _args['toast-activator-clsid'] ?? toastActivatorYaml['clsid']?.toString();
+    toastActivatorArguments = _args['toast-activator-arguments'] ?? toastActivatorYaml['arguments']?.toString() ?? '----AppNotificationActivationServer';
+    toastActivatorDisplayName = _args['toast-activator-display-name'] ?? toastActivatorYaml['display_name']?.toString() ?? 'Toast activator';
 
     // app installer configurations
     dynamic installerYaml = yaml['app_installer'] ?? YamlMap();
 
-    publishFolderPath =
-        _args['publish-folder-path'] ?? installerYaml['publish_folder_path'];
-    hoursBetweenUpdateChecks = int.parse(_args['hours-between-update-checks'] ??
-        installerYaml['hours_between_update_checks']?.toString() ??
-        '0');
+    publishFolderPath = _args['publish-folder-path'] ?? installerYaml['publish_folder_path'];
+    hoursBetweenUpdateChecks = int.parse(_args['hours-between-update-checks'] ?? installerYaml['hours_between_update_checks']?.toString() ?? '0');
     if (hoursBetweenUpdateChecks < 0) hoursBetweenUpdateChecks = 0;
-    automaticBackgroundTask = _args.wasParsed('automatic-background-task') ||
-        installerYaml['automatic_background_task']?.toString().toLowerCase() ==
-            'true';
-    updateBlocksActivation = _args.wasParsed('update-blocks-activation') ||
-        installerYaml['update_blocks_activation']?.toString().toLowerCase() ==
-            'true';
-    showPrompt = _args.wasParsed('show-prompt') ||
-        installerYaml['show_prompt']?.toString().toLowerCase() == 'true';
-    forceUpdateFromAnyVersion =
-        _args.wasParsed('force-update-from-any-version') ||
-            installerYaml['force_update_from_any_version']
-                    ?.toString()
-                    .toLowerCase() ==
-                'true';
+    automaticBackgroundTask = _args.wasParsed('automatic-background-task') || installerYaml['automatic_background_task']?.toString().toLowerCase() == 'true';
+    updateBlocksActivation = _args.wasParsed('update-blocks-activation') || installerYaml['update_blocks_activation']?.toString().toLowerCase() == 'true';
+    showPrompt = _args.wasParsed('show-prompt') || installerYaml['show_prompt']?.toString().toLowerCase() == 'true';
+    forceUpdateFromAnyVersion = _args.wasParsed('force-update-from-any-version') || installerYaml['force_update_from_any_version']?.toString().toLowerCase() == 'true';
 
     // context menu configurations
     dynamic contextMenuYaml = yaml['context_menu'];
 
     bool skipContextMenu = _args.wasParsed('skip-context-menu');
 
-    contextMenuConfiguration = contextMenuYaml != null &&
-            contextMenuYaml is YamlMap &&
-            !skipContextMenu
-        ? ContextMenuConfiguration.fromYaml(contextMenuYaml)
-        : null;
+    contextMenuConfiguration = contextMenuYaml != null && contextMenuYaml is YamlMap && !skipContextMenu ? ContextMenuConfiguration.fromYaml(contextMenuYaml) : null;
   }
 
   /// Validate the configuration values and set default values
@@ -211,8 +172,7 @@ class Configuration {
     if (displayName.isNull) displayName = cleanAppName;
     if (identityName.isNull) {
       if (store) {
-        _logger.stderr(
-            'identity name is empty, check "msix_config: identity_name" at pubspec.yaml');
+        _logger.stderr('identity name is empty, check "msix_config: identity_name" at pubspec.yaml');
         throw 'you can find your store "identity_name" in https://partner.microsoft.com/en-us/dashboard > Product > Product identity > Package/Identity/Name';
       } else {
         identityName = 'com.flutter.$cleanAppName';
@@ -224,21 +184,18 @@ class Configuration {
     }
     if (publisherName.isNull) {
       if (store) {
-        _logger.stderr(
-            'publisher display name is empty, check "msix_config: publisher_display_name" at pubspec.yaml');
+        _logger.stderr('publisher display name is empty, check "msix_config: publisher_display_name" at pubspec.yaml');
         throw 'you can find your store "publisher_display_name" in https://partner.microsoft.com/en-us/dashboard > Product > Product identity > Package/Properties/PublisherDisplayName';
       } else {
         publisherName = identityName;
       }
     }
     if (signMsix == false && publisher.isNullOrEmpty) {
-      _logger.stderr(
-          'when sign_msix is false, you must provide the publisher value at "msix_config: publisher" in the pubspec.yaml file');
+      _logger.stderr('when sign_msix is false, you must provide the publisher value at "msix_config: publisher" in the pubspec.yaml file');
       exit(-1);
     }
     if (store && publisher.isNullOrEmpty) {
-      _logger.stderr(
-          'publisher is empty, check "msix_config: publisher" at pubspec.yaml');
+      _logger.stderr('publisher is empty, check "msix_config: publisher" at pubspec.yaml');
       throw 'you can find your store "publisher" in https://partner.microsoft.com/en-us/dashboard > Product > Product identity > Package/Properties/Publisher';
     }
     if (msixVersion.isNull) msixVersion = '1.0.0.0';
@@ -265,16 +222,13 @@ class Configuration {
       throw '"publisher display name" is too long, it should be less than 256 characters';
     }
 
-    if (!certificatePath.isNull ||
-        (SignTool.isCustomSignCommand(signToolOptions)) ||
-        store) {
+    if (!certificatePath.isNull || (SignTool.isCustomSignCommand(signToolOptions)) || store) {
       if (!certificatePath.isNull) {
         if (!(await File(certificatePath!).exists())) {
           throw 'The file certificate not found in: $certificatePath, check "msix_config: certificate_path" at pubspec.yaml';
         }
 
-        if (extension(certificatePath!).toLowerCase() == '.pfx' &&
-            certificatePassword.isNull) {
+        if (extension(certificatePath!).toLowerCase() == '.pfx' && certificatePassword.isNull) {
           throw 'Certificate password is empty, check "msix_config: certificate_password" at pubspec.yaml';
         }
       }
@@ -307,10 +261,7 @@ class Configuration {
           throw 'Context menu item commands is empty';
         }
 
-        if (contextMenuConfiguration!.items
-                .where((element) => element.type == item.type)
-                .length >
-            1) {
+        if (contextMenuConfiguration!.items.where((element) => element.type == item.type).length > 1) {
           throw 'Found same context menu item type more than once, type must be unique for each item. Type: ${item.type}';
         }
 
@@ -323,8 +274,7 @@ class Configuration {
             throw 'Context menu command clsid is empty';
           }
 
-          if (command.customDllPath != null &&
-              !await File(command.customDllPath!).exists()) {
+          if (command.customDllPath != null && !await File(command.customDllPath!).exists()) {
             throw 'The context menu command custom dll file not found in: ${command.customDllPath}, check "msix_config: context_menu: items: commands: custom_dll" at pubspec.yaml';
           }
 
@@ -332,18 +282,12 @@ class Configuration {
             throw 'Context menu command clsid cannot be the same as toast activator clsid, Clsid: ${command.clsid}';
           }
 
-          if (item.commands
-                  .where((element) => element.clsid == command.clsid)
-                  .length >
-              1) {
+          if (item.commands.where((element) => element.clsid == command.clsid).length > 1) {
             throw 'Found same context menu command more than once in same type. Clsid: ${command.clsid}, Type: ${item.type}';
           }
 
-          for (List<ContextMenuItemCommand> command2
-              in contextMenuConfiguration!.items.map((e) => e.commands)) {
-            if (command2.any((element) =>
-                element.clsid == command.clsid &&
-                element.customDllPath != command.customDllPath)) {
+          for (List<ContextMenuItemCommand> command2 in contextMenuConfiguration!.items.map((e) => e.commands)) {
+            if (command2.any((element) => element.clsid == command.clsid && element.customDllPath != command.customDllPath)) {
               throw 'Context menu command clsid must be unique for each class, but found duplicate.\nClsid: ${command.clsid} with different dll path: ${command.customDllPath ?? contextMenuConfiguration!.dllPath} and ${command2.firstWhere((element) => element.id == command.id).customDllPath}';
             }
           }
@@ -358,19 +302,11 @@ class Configuration {
 
     _logger.trace('validating build files');
 
-    if (!await Directory(buildFilesFolder).exists() ||
-        !await Directory(buildFilesFolder)
-            .list()
-            .any((file) => file.path.endsWith('.exe'))) {
+    if (!await Directory(buildFilesFolder).exists() || !await Directory(buildFilesFolder).list().any((file) => file.path.endsWith('.exe'))) {
       throw 'Build files not found at $buildFilesFolder, first run "flutter build windows" then try again';
     }
 
-    executableFileName = await Directory(buildFilesFolder)
-        .list()
-        .firstWhere((file) =>
-            file.path.endsWith('.exe') &&
-            !file.path.contains('PSFLauncher64.exe'))
-        .then((file) => basename(file.path));
+    executableFileName = await _getExecutableFileName();
   }
 
   /// Declare and parse the cli arguments
@@ -422,22 +358,16 @@ class Configuration {
   }
 
   Future<String> _updateBuildFilesFolder() async {
-    final String buildFilesFolderStart =
-        buildFilesFolder.substring(0, buildFilesFolder.lastIndexOf('runner'));
-    final String buildFilesFolderArchitecture =
-        p.join(buildFilesFolderStart, architecture);
-    final String buildFilesFolderEnd =
-        buildFilesFolder.substring(buildFilesFolder.lastIndexOf('runner'));
+    final String buildFilesFolderStart = buildFilesFolder.substring(0, buildFilesFolder.lastIndexOf('runner'));
+    final String buildFilesFolderArchitecture = p.join(buildFilesFolderStart, architecture);
+    final String buildFilesFolderEnd = buildFilesFolder.substring(buildFilesFolder.lastIndexOf('runner'));
 
-    if (architecture == 'arm64' &&
-        !(await Directory(buildFilesFolderArchitecture).exists())) {
-      _logger.stderr(
-          'cannot find arm64 build folder at: $buildFilesFolderArchitecture');
+    if (architecture == 'arm64' && !(await Directory(buildFilesFolderArchitecture).exists())) {
+      _logger.stderr('cannot find arm64 build folder at: $buildFilesFolderArchitecture');
       exit(-1);
     }
 
-    if (await Directory(p.join(buildFilesFolderArchitecture, 'runner'))
-        .exists()) {
+    if (await Directory(p.join(buildFilesFolderArchitecture, 'runner')).exists()) {
       return p.join(buildFilesFolderStart, architecture, buildFilesFolderEnd);
     } else {
       return p.join(buildFilesFolderStart, buildFilesFolderEnd);
@@ -447,14 +377,8 @@ class Configuration {
   Future<void> validateAppInstallerConfigValues() async {
     _logger.trace('validating app installer config values');
 
-    if (publishFolderPath.isNullOrEmpty ||
-        (!await Directory(publishFolderPath!).exists() &&
-            !await Directory(publishFolderPath =
-                    '${Directory.current.path}\\${publishFolderPath!}')
-                .exists())) {
-      _logger.stderr(
-          'publish folder path is not exists, check "app_installer: publish_folder_path" at pubspec.yaml'
-              .red);
+    if (publishFolderPath.isNullOrEmpty || (!await Directory(publishFolderPath!).exists() && !await Directory(publishFolderPath = '${Directory.current.path}\\${publishFolderPath!}').exists())) {
+      _logger.stderr('publish folder path is not exists, check "app_installer: publish_folder_path" at pubspec.yaml'.red);
       exit(-1);
     } else {
       publishFolderPath = Uri.decodeFull(publishFolderPath!);
@@ -481,8 +405,7 @@ class Configuration {
       throw 'Failed to locate msix assets path.';
     }
 
-    String path =
-        '${msixPackage.packageUriRoot.toString().replaceAll('file:///', '')}assets';
+    String path = '${msixPackage.packageUriRoot.toString().replaceAll('file:///', '')}assets';
 
     msixAssetsPath = Uri.decodeFull(path);
   }
@@ -499,48 +422,103 @@ class Configuration {
     if (yaml['version'] == null) return null;
     try {
       final Version pubspecVersion = Version.parse(yaml['version']);
-      return [
-        pubspecVersion.major,
-        pubspecVersion.minor,
-        pubspecVersion.patch,
-        0
-      ].join('.');
+      return [pubspecVersion.major, pubspecVersion.minor, pubspecVersion.patch, 0].join('.');
     } on FormatException {
-      _logger.stderr(
-        'Warning: Could not parse Pubspec version. No version provided.',
-      );
+      _logger.stderr('Warning: Could not parse Pubspec version. No version provided.');
       return null;
     }
   }
 
   /// Get the languages list
-  Iterable<String>? _getLanguages(dynamic config) =>
-      ((_args['languages'] ?? config['languages']) as String?)
-          ?.split(',')
-          .map((e) => e.trim())
-          .where((element) => element.isNotEmpty);
+  Iterable<String>? _getLanguages(dynamic config) => ((_args['languages'] ?? config['languages']) as String?)?.split(',').map((e) => e.trim()).where((element) => element.isNotEmpty);
 
   /// Get the app uri handler hosts list
-  Iterable<String>? _getAppUriHandlerHosts(dynamic config) =>
-      ((_args['app-uri-handler-hosts'] ?? config['app_uri_handler_hosts'])
-              as String?)
-          ?.split(',')
-          .map((e) => e.trim())
-          .where((element) => element.isNotEmpty);
+  Iterable<String>? _getAppUriHandlerHosts(dynamic config) => ((_args['app-uri-handler-hosts'] ?? config['app_uri_handler_hosts']) as String?)?.split(',').map((e) => e.trim()).where((element) => element.isNotEmpty);
 
   /// Get the protocol activation list
-  Iterable<String> _getProtocolsActivation(dynamic config) =>
-      ((_args['protocol-activation'] ?? config['protocol_activation'])
-              as String?)
-          ?.split(',')
-          .map((protocol) => protocol
-              .trim()
-              .toLowerCase()
-              .replaceAll('://', '')
-              .replaceAll(':/', '')
-              .replaceAll(':', ''))
-          .where((protocol) => protocol.isNotEmpty) ??
-      [];
+  Iterable<String> _getProtocolsActivation(dynamic config) => ((_args['protocol-activation'] ?? config['protocol_activation']) as String?)?.split(',').map((protocol) => protocol.trim().toLowerCase().replaceAll('://', '').replaceAll(':/', '').replaceAll(':', '')).where((protocol) => protocol.isNotEmpty) ?? [];
+
+  Future<String> _getExecutableFileName() async {
+    //Try to obtain executable name from CMake
+    String? executableName = await _getExecutableFromCMake();
+    if (executableName != null) {
+      _logger.trace('executable name found from CMake: $executableName');
+      return executableName;
+    }
+
+    //Try to obtain executable name from pubspec.yaml (app name)
+    executableName = await _getExecutableFromPubspec();
+    if (executableName != null) {
+      _logger.trace('executable name found from pubspec: $executableName');
+      return executableName;
+    }
+
+    // Fallback to searching the build files folder
+    _logger.trace('using fallback method to find executable');
+    return await Directory(buildFilesFolder).list().firstWhere((file) => file.path.endsWith('.exe') && !file.path.contains('PSFLauncher64.exe')).then((file) => p.basename(file.path));
+  }
+
+  Future<String?> _getExecutableFromCMake() async {
+    try {
+      // Procura pelo CMakeLists.txt na pasta windows
+      final windowsPath = p.join(Directory.current.path, 'windows');
+      final cmakeFile = File(p.join(windowsPath, 'CMakeLists.txt'));
+
+      if (await cmakeFile.exists()) {
+        final content = await cmakeFile.readAsString();
+        final binaryNameMatch = RegExp(r'set\s*\(\s*BINARY_NAME\s+"([^"]+)"\s*\)', caseSensitive: false).firstMatch(content);
+        if (binaryNameMatch != null) {
+          return '${binaryNameMatch.group(1)}.exe';
+        }
+
+        final projectMatch = RegExp(r'project\s*\(\s*([^\s\)]+)', caseSensitive: false).firstMatch(content);
+        if (projectMatch != null) {
+          String projectName = projectMatch.group(1)!.replaceAll('"', '');
+          final expectedExe = '$projectName.exe';
+          if (await File(p.join(buildFilesFolder, expectedExe)).exists()) {
+            return expectedExe;
+          }
+        }
+      }
+      final runnerCmakeFile = File(p.join(windowsPath, 'runner', 'CMakeLists.txt'));
+      if (await runnerCmakeFile.exists()) {
+        final content = await runnerCmakeFile.readAsString();
+
+        final binaryNameMatch = RegExp(r'set\s*\(\s*BINARY_NAME\s+"([^"]+)"\s*\)', caseSensitive: false).firstMatch(content);
+        if (binaryNameMatch != null) {
+          return '${binaryNameMatch.group(1)}.exe';
+        }
+      }
+    } catch (e) {
+      _logger.trace('Error reading CMake files: $e');
+    }
+    return null;
+  }
+
+  Future<String?> _getExecutableFromPubspec() async {
+    try {
+      if (appName != null && appName!.isNotEmpty) {
+        final expectedExe = '$appName.exe';
+        if (await File(p.join(buildFilesFolder, expectedExe)).exists()) {
+          return expectedExe;
+        }
+
+        final cleanAppName = appName!.replaceAll('_', '');
+        final expectedCleanExe = '$cleanAppName.exe';
+        if (await File(p.join(buildFilesFolder, expectedCleanExe)).exists()) {
+          return expectedCleanExe;
+        }
+
+        final lowercaseExe = '${appName!.toLowerCase()}.exe';
+        if (await File(p.join(buildFilesFolder, lowercaseExe)).exists()) {
+          return lowercaseExe;
+        }
+      }
+    } catch (e) {
+      _logger.trace('Error checking executable from pubspec: $e');
+    }
+    return null;
+  }
 }
 
 /// A more advanced version of 'enable_at_startup'.
@@ -555,17 +533,9 @@ class StartupTask {
   /// This is useful to detect if the app was started automatically.
   final String? parameters;
 
-  StartupTask({
-    required this.taskId,
-    required this.enabled,
-    required this.parameters,
-  });
+  StartupTask({required this.taskId, required this.enabled, required this.parameters});
 
   factory StartupTask.fromMap(Map map, String appName) {
-    return StartupTask(
-      taskId: map['task_id'] ?? appName.replaceAll('_', ''),
-      enabled: map['enabled'] ?? true,
-      parameters: map['parameters'],
-    );
+    return StartupTask(taskId: map['task_id'] ?? appName.replaceAll('_', ''), enabled: map['enabled'] ?? true, parameters: map['parameters']);
   }
 }

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -481,7 +481,7 @@ class Configuration {
       if (await cmakeFile.exists()) {
         final content = await cmakeFile.readAsString();
         final binaryNameMatch = RegExp(r'set\s*\(\s*BINARY_NAME\s+"([^"]+)"\s*\)', caseSensitive: false).firstMatch(content);
-        _logger.progress('Searching for executable name in CMakeLists.txt: $cmakeFile');
+        _logger.progress('Searching for executable name in CMakeLists.txt: $binaryNameMatch');
         _logger.trace('CMakeLists.txt content: $content');
         if (binaryNameMatch != null) {
           return '${binaryNameMatch.group(1)}.exe';

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -475,13 +475,14 @@ class Configuration {
 
   Future<String?> _getExecutableFromCMake() async {
     try {
-      // Procura pelo CMakeLists.txt na pasta windows
       final windowsPath = p.join(Directory.current.path, 'windows');
       final cmakeFile = File(p.join(windowsPath, 'CMakeLists.txt'));
 
       if (await cmakeFile.exists()) {
         final content = await cmakeFile.readAsString();
         final binaryNameMatch = RegExp(r'set\s*\(\s*BINARY_NAME\s+"([^"]+)"\s*\)', caseSensitive: false).firstMatch(content);
+        _logger.progress('Searching for executable name in CMakeLists.txt: $cmakeFile');
+        _logger.trace('CMakeLists.txt content: $content');
         if (binaryNameMatch != null) {
           return '${binaryNameMatch.group(1)}.exe';
         }
@@ -493,15 +494,6 @@ class Configuration {
           if (await File(p.join(buildFilesFolder, expectedExe)).exists()) {
             return expectedExe;
           }
-        }
-      }
-      final runnerCmakeFile = File(p.join(windowsPath, 'runner', 'CMakeLists.txt'));
-      if (await runnerCmakeFile.exists()) {
-        final content = await runnerCmakeFile.readAsString();
-
-        final binaryNameMatch = RegExp(r'set\s*\(\s*BINARY_NAME\s+"([^"]+)"\s*\)', caseSensitive: false).firstMatch(content);
-        if (binaryNameMatch != null) {
-          return '${binaryNameMatch.group(1)}.exe';
         }
       }
     } catch (e) {

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -311,7 +311,6 @@ class Configuration {
       _logger.stderr('No executable file found in $buildFilesFolder, first run "flutter build windows" then try again');
       exit(-1);
     }
-    _logger.progress('executable file name: $executableFileName');
   }
 
   /// Declare and parse the cli arguments
@@ -448,21 +447,29 @@ class Configuration {
     //Try to obtain executable name from CMake
     String? executableName = await _getExecutableFromCMake();
     if (executableName != null) {
-      _logger.trace('executable name found from CMake: $executableName');
+      _logger.progress('executable name found from CMake: $executableName');
       return executableName;
     }
-    _logger.trace('executable name not found from CMake, trying pubspec.yaml');
+    _logger.progress('executable name not found from CMake, trying pubspec.yaml');
 
     //Try to obtain executable name from pubspec.yaml (app name)
     executableName = await _getExecutableFromPubspec();
     if (executableName != null) {
-      _logger.trace('executable name found from pubspec: $executableName');
+      _logger.progress('executable name found from pubspec: $executableName');
       return executableName;
     }
-    _logger.trace('executable name not found from pubspec, trying fallback method');
+    _logger.progress('executable name not found from pubspec, trying fallback method');
     // Fallback to searching the build files folder
-    _logger.trace('using fallback method to find executable');
-    return await Directory(buildFilesFolder).list().firstWhere((file) => file.path.endsWith('.exe') && !file.path.contains('PSFLauncher64.exe')).then((file) => p.basename(file.path));
+    _logger.progress('using fallback method to find executable');
+    executableName = await Directory(buildFilesFolder).list().firstWhere((file) => file.path.endsWith('.exe') && !file.path.contains('PSFLauncher64.exe')).then((file) => p.basename(file.path));
+    _logger.progress('executable name found from fallback method: $executableName');
+    if (executableName == null) {
+      _logger.stderr('No executable file found in $buildFilesFolder, first run "flutter build windows" then try again');
+      exit(-1);
+    } else {
+      _logger.progress('executable name: $executableName');
+      return executableName;
+    }
   }
 
   Future<String?> _getExecutableFromCMake() async {

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -25,7 +25,8 @@ class Configuration {
   String? identityName;
   String? msixVersion;
   String? appDescription;
-  String buildFilesFolder = p.join(Directory.current.path, 'build', 'windows', 'runner', 'Release');
+  String buildFilesFolder =
+      p.join(Directory.current.path, 'build', 'windows', 'runner', 'Release');
   String? certificatePath;
   String? certificatePassword;
   String? publisher;
@@ -61,9 +62,12 @@ class Configuration {
   Iterable<String>? appUriHandlerHosts;
   Iterable<String>? languages;
   String get defaultsIconsFolderPath => p.join(msixAssetsPath, 'icons');
-  String get msixToolkitPath => p.join(msixAssetsPath, 'MSIX-Toolkit', 'Redist.x64');
-  String get msixPath => p.join(outputPath ?? buildFilesFolder, '${outputName ?? appName}.msix');
-  String get appInstallerPath => p.join(publishFolderPath!, basename(msixPath).replaceAll('.msix', '.appinstaller'));
+  String get msixToolkitPath =>
+      p.join(msixAssetsPath, 'MSIX-Toolkit', 'Redist.x64');
+  String get msixPath =>
+      p.join(outputPath ?? buildFilesFolder, '${outputName ?? appName}.msix');
+  String get appInstallerPath => p.join(publishFolderPath!,
+      basename(msixPath).replaceAll('.msix', '.appinstaller'));
   String pubspecYamlPath = "pubspec.yaml";
   String osMinVersion = '10.0.17763.0';
   bool isTestCertificate = false;
@@ -79,41 +83,53 @@ class Configuration {
     appName = pubspec['name'];
     appDescription = pubspec['description'];
     dynamic yaml = pubspec['msix_config'] ?? YamlMap();
-    msixVersion = _args['version'] ?? yaml['msix_version'] ?? _getPubspecVersion(pubspec);
+    msixVersion =
+        _args['version'] ?? yaml['msix_version'] ?? _getPubspecVersion(pubspec);
     certificatePath = _args['certificate-path'] ?? yaml['certificate_path'];
-    certificatePassword = _args['certificate-password'] ?? yaml['certificate_password']?.toString();
+    certificatePassword = _args['certificate-password'] ??
+        yaml['certificate_password']?.toString();
     outputPath = _args['output-path'] ?? yaml['output_path'];
     outputName = _args['output-name'] ?? yaml['output_name'];
     executionAlias = _args['execution-alias'] ?? yaml['execution_alias'];
-    if (_args['sign-msix'].toString() == 'false' || yaml['sign_msix']?.toString().toLowerCase() == 'false') {
+    if (_args['sign-msix'].toString() == 'false' ||
+        yaml['sign_msix']?.toString().toLowerCase() == 'false') {
       signMsix = false;
     }
-    if (_args['install-certificate'].toString() == 'false' || yaml['install_certificate']?.toString().toLowerCase() == 'false') {
+    if (_args['install-certificate'].toString() == 'false' ||
+        yaml['install_certificate']?.toString().toLowerCase() == 'false') {
       installCert = false;
     }
-    if (_args['build-windows'].toString() == 'false' || yaml['build_windows']?.toString().toLowerCase() == 'false') {
+    if (_args['build-windows'].toString() == 'false' ||
+        yaml['build_windows']?.toString().toLowerCase() == 'false') {
       buildWindows = false;
     }
-    if (_args['trim-logo'].toString() == 'false' || yaml['trim_logo']?.toString().toLowerCase() == 'false') {
+    if (_args['trim-logo'].toString() == 'false' ||
+        yaml['trim_logo']?.toString().toLowerCase() == 'false') {
       trimLogo = false;
     }
-    store = _args.wasParsed('store') || yaml['store']?.toString().toLowerCase() == 'true';
-    createWithDebugBuildFiles = _args.wasParsed('debug') || yaml['debug']?.toString().toLowerCase() == 'true';
+    store = _args.wasParsed('store') ||
+        yaml['store']?.toString().toLowerCase() == 'true';
+    createWithDebugBuildFiles = _args.wasParsed('debug') ||
+        yaml['debug']?.toString().toLowerCase() == 'true';
 
     displayName = _args['display-name'] ?? yaml['display_name'];
-    publisherName = _args['publisher-display-name'] ?? yaml['publisher_display_name'];
+    publisherName =
+        _args['publisher-display-name'] ?? yaml['publisher_display_name'];
     publisher = _args['publisher'] ?? yaml['publisher'];
     identityName = _args['identity-name'] ?? yaml['identity_name'];
     logoPath = _args['logo-path'] ?? yaml['logo_path'];
-    osMinVersion = _args['os-min-version'] ?? yaml['os_min_version'] ?? osMinVersion;
+    osMinVersion =
+        _args['os-min-version'] ?? yaml['os_min_version'] ?? osMinVersion;
 
-    final String? signToolOptionsConfig = (_args['signtool-options'] ?? yaml['signtool_options'])?.toString();
+    final String? signToolOptionsConfig =
+        (_args['signtool-options'] ?? yaml['signtool_options'])?.toString();
     if (signToolOptionsConfig != null && signToolOptionsConfig.isNotEmpty) {
       CommandLineConverter commandLineConverter = CommandLineConverter();
       signToolOptions = commandLineConverter.convert(signToolOptionsConfig);
     }
 
-    final String? windowsBuildArgsConfig = (_args['windows-build-args'] ?? yaml['windows_build_args'])?.toString();
+    final String? windowsBuildArgsConfig =
+        (_args['windows-build-args'] ?? yaml['windows_build_args'])?.toString();
     if (windowsBuildArgsConfig != null && windowsBuildArgsConfig.isNotEmpty) {
       CommandLineConverter commandLineConverter = CommandLineConverter();
       windowsBuildArgs = commandLineConverter.convert(windowsBuildArgsConfig);
@@ -129,35 +145,60 @@ class Configuration {
     capabilities = _args['capabilities'] ?? yaml['capabilities'];
     languages = _getLanguages(yaml);
     appUriHandlerHosts = _getAppUriHandlerHosts(yaml);
-    enableAtStartup = _args.wasParsed('enable-at-startup') || yaml['enable_at_startup']?.toString().toLowerCase() == 'true';
+    enableAtStartup = _args.wasParsed('enable-at-startup') ||
+        yaml['enable_at_startup']?.toString().toLowerCase() == 'true';
 
     // A more advanced version of 'enable_at_startup'
-    startupTask = yaml['startup_task'] != null ? StartupTask.fromMap(yaml['startup_task'], appName!) : null;
+    startupTask = yaml['startup_task'] != null
+        ? StartupTask.fromMap(yaml['startup_task'], appName!)
+        : null;
 
     // toast activator configurations
     dynamic toastActivatorYaml = yaml['toast_activator'] ?? YamlMap();
 
-    toastActivatorCLSID = _args['toast-activator-clsid'] ?? toastActivatorYaml['clsid']?.toString();
-    toastActivatorArguments = _args['toast-activator-arguments'] ?? toastActivatorYaml['arguments']?.toString() ?? '----AppNotificationActivationServer';
-    toastActivatorDisplayName = _args['toast-activator-display-name'] ?? toastActivatorYaml['display_name']?.toString() ?? 'Toast activator';
+    toastActivatorCLSID = _args['toast-activator-clsid'] ??
+        toastActivatorYaml['clsid']?.toString();
+    toastActivatorArguments = _args['toast-activator-arguments'] ??
+        toastActivatorYaml['arguments']?.toString() ??
+        '----AppNotificationActivationServer';
+    toastActivatorDisplayName = _args['toast-activator-display-name'] ??
+        toastActivatorYaml['display_name']?.toString() ??
+        'Toast activator';
 
     // app installer configurations
     dynamic installerYaml = yaml['app_installer'] ?? YamlMap();
 
-    publishFolderPath = _args['publish-folder-path'] ?? installerYaml['publish_folder_path'];
-    hoursBetweenUpdateChecks = int.parse(_args['hours-between-update-checks'] ?? installerYaml['hours_between_update_checks']?.toString() ?? '0');
+    publishFolderPath =
+        _args['publish-folder-path'] ?? installerYaml['publish_folder_path'];
+    hoursBetweenUpdateChecks = int.parse(_args['hours-between-update-checks'] ??
+        installerYaml['hours_between_update_checks']?.toString() ??
+        '0');
     if (hoursBetweenUpdateChecks < 0) hoursBetweenUpdateChecks = 0;
-    automaticBackgroundTask = _args.wasParsed('automatic-background-task') || installerYaml['automatic_background_task']?.toString().toLowerCase() == 'true';
-    updateBlocksActivation = _args.wasParsed('update-blocks-activation') || installerYaml['update_blocks_activation']?.toString().toLowerCase() == 'true';
-    showPrompt = _args.wasParsed('show-prompt') || installerYaml['show_prompt']?.toString().toLowerCase() == 'true';
-    forceUpdateFromAnyVersion = _args.wasParsed('force-update-from-any-version') || installerYaml['force_update_from_any_version']?.toString().toLowerCase() == 'true';
+    automaticBackgroundTask = _args.wasParsed('automatic-background-task') ||
+        installerYaml['automatic_background_task']?.toString().toLowerCase() ==
+            'true';
+    updateBlocksActivation = _args.wasParsed('update-blocks-activation') ||
+        installerYaml['update_blocks_activation']?.toString().toLowerCase() ==
+            'true';
+    showPrompt = _args.wasParsed('show-prompt') ||
+        installerYaml['show_prompt']?.toString().toLowerCase() == 'true';
+    forceUpdateFromAnyVersion =
+        _args.wasParsed('force-update-from-any-version') ||
+            installerYaml['force_update_from_any_version']
+                    ?.toString()
+                    .toLowerCase() ==
+                'true';
 
     // context menu configurations
     dynamic contextMenuYaml = yaml['context_menu'];
 
     bool skipContextMenu = _args.wasParsed('skip-context-menu');
 
-    contextMenuConfiguration = contextMenuYaml != null && contextMenuYaml is YamlMap && !skipContextMenu ? ContextMenuConfiguration.fromYaml(contextMenuYaml) : null;
+    contextMenuConfiguration = contextMenuYaml != null &&
+            contextMenuYaml is YamlMap &&
+            !skipContextMenu
+        ? ContextMenuConfiguration.fromYaml(contextMenuYaml)
+        : null;
   }
 
   /// Validate the configuration values and set default values
@@ -172,7 +213,8 @@ class Configuration {
     if (displayName.isNull) displayName = cleanAppName;
     if (identityName.isNull) {
       if (store) {
-        _logger.stderr('identity name is empty, check "msix_config: identity_name" at pubspec.yaml');
+        _logger.stderr(
+            'identity name is empty, check "msix_config: identity_name" at pubspec.yaml');
         throw 'you can find your store "identity_name" in https://partner.microsoft.com/en-us/dashboard > Product > Product identity > Package/Identity/Name';
       } else {
         identityName = 'com.flutter.$cleanAppName';
@@ -184,18 +226,21 @@ class Configuration {
     }
     if (publisherName.isNull) {
       if (store) {
-        _logger.stderr('publisher display name is empty, check "msix_config: publisher_display_name" at pubspec.yaml');
+        _logger.stderr(
+            'publisher display name is empty, check "msix_config: publisher_display_name" at pubspec.yaml');
         throw 'you can find your store "publisher_display_name" in https://partner.microsoft.com/en-us/dashboard > Product > Product identity > Package/Properties/PublisherDisplayName';
       } else {
         publisherName = identityName;
       }
     }
     if (signMsix == false && publisher.isNullOrEmpty) {
-      _logger.stderr('when sign_msix is false, you must provide the publisher value at "msix_config: publisher" in the pubspec.yaml file');
+      _logger.stderr(
+          'when sign_msix is false, you must provide the publisher value at "msix_config: publisher" in the pubspec.yaml file');
       exit(-1);
     }
     if (store && publisher.isNullOrEmpty) {
-      _logger.stderr('publisher is empty, check "msix_config: publisher" at pubspec.yaml');
+      _logger.stderr(
+          'publisher is empty, check "msix_config: publisher" at pubspec.yaml');
       throw 'you can find your store "publisher" in https://partner.microsoft.com/en-us/dashboard > Product > Product identity > Package/Properties/Publisher';
     }
     if (msixVersion.isNull) msixVersion = '1.0.0.0';
@@ -222,13 +267,16 @@ class Configuration {
       throw '"publisher display name" is too long, it should be less than 256 characters';
     }
 
-    if (!certificatePath.isNull || (SignTool.isCustomSignCommand(signToolOptions)) || store) {
+    if (!certificatePath.isNull ||
+        (SignTool.isCustomSignCommand(signToolOptions)) ||
+        store) {
       if (!certificatePath.isNull) {
         if (!(await File(certificatePath!).exists())) {
           throw 'The file certificate not found in: $certificatePath, check "msix_config: certificate_path" at pubspec.yaml';
         }
 
-        if (extension(certificatePath!).toLowerCase() == '.pfx' && certificatePassword.isNull) {
+        if (extension(certificatePath!).toLowerCase() == '.pfx' &&
+            certificatePassword.isNull) {
           throw 'Certificate password is empty, check "msix_config: certificate_password" at pubspec.yaml';
         }
       }
@@ -261,7 +309,10 @@ class Configuration {
           throw 'Context menu item commands is empty';
         }
 
-        if (contextMenuConfiguration!.items.where((element) => element.type == item.type).length > 1) {
+        if (contextMenuConfiguration!.items
+                .where((element) => element.type == item.type)
+                .length >
+            1) {
           throw 'Found same context menu item type more than once, type must be unique for each item. Type: ${item.type}';
         }
 
@@ -274,7 +325,8 @@ class Configuration {
             throw 'Context menu command clsid is empty';
           }
 
-          if (command.customDllPath != null && !await File(command.customDllPath!).exists()) {
+          if (command.customDllPath != null &&
+              !await File(command.customDllPath!).exists()) {
             throw 'The context menu command custom dll file not found in: ${command.customDllPath}, check "msix_config: context_menu: items: commands: custom_dll" at pubspec.yaml';
           }
 
@@ -282,12 +334,18 @@ class Configuration {
             throw 'Context menu command clsid cannot be the same as toast activator clsid, Clsid: ${command.clsid}';
           }
 
-          if (item.commands.where((element) => element.clsid == command.clsid).length > 1) {
+          if (item.commands
+                  .where((element) => element.clsid == command.clsid)
+                  .length >
+              1) {
             throw 'Found same context menu command more than once in same type. Clsid: ${command.clsid}, Type: ${item.type}';
           }
 
-          for (List<ContextMenuItemCommand> command2 in contextMenuConfiguration!.items.map((e) => e.commands)) {
-            if (command2.any((element) => element.clsid == command.clsid && element.customDllPath != command.customDllPath)) {
+          for (List<ContextMenuItemCommand> command2
+              in contextMenuConfiguration!.items.map((e) => e.commands)) {
+            if (command2.any((element) =>
+                element.clsid == command.clsid &&
+                element.customDllPath != command.customDllPath)) {
               throw 'Context menu command clsid must be unique for each class, but found duplicate.\nClsid: ${command.clsid} with different dll path: ${command.customDllPath ?? contextMenuConfiguration!.dllPath} and ${command2.firstWhere((element) => element.id == command.id).customDllPath}';
             }
           }
@@ -302,13 +360,17 @@ class Configuration {
 
     _logger.trace('validating build files');
 
-    if (!await Directory(buildFilesFolder).exists() || !await Directory(buildFilesFolder).list().any((file) => file.path.endsWith('.exe'))) {
+    if (!await Directory(buildFilesFolder).exists() ||
+        !await Directory(buildFilesFolder)
+            .list()
+            .any((file) => file.path.endsWith('.exe'))) {
       throw 'Build files not found at $buildFilesFolder, first run "flutter build windows" then try again';
     }
 
     executableFileName = await _getExecutableFileName();
     if (executableFileName == null) {
-      _logger.stderr('No executable file found in $buildFilesFolder, first run "flutter build windows" then try again');
+      _logger.stderr(
+          'No executable file found in $buildFilesFolder, first run "flutter build windows" then try again');
       exit(-1);
     }
   }
@@ -362,16 +424,22 @@ class Configuration {
   }
 
   Future<String> _updateBuildFilesFolder() async {
-    final String buildFilesFolderStart = buildFilesFolder.substring(0, buildFilesFolder.lastIndexOf('runner'));
-    final String buildFilesFolderArchitecture = p.join(buildFilesFolderStart, architecture);
-    final String buildFilesFolderEnd = buildFilesFolder.substring(buildFilesFolder.lastIndexOf('runner'));
+    final String buildFilesFolderStart =
+        buildFilesFolder.substring(0, buildFilesFolder.lastIndexOf('runner'));
+    final String buildFilesFolderArchitecture =
+        p.join(buildFilesFolderStart, architecture);
+    final String buildFilesFolderEnd =
+        buildFilesFolder.substring(buildFilesFolder.lastIndexOf('runner'));
 
-    if (architecture == 'arm64' && !(await Directory(buildFilesFolderArchitecture).exists())) {
-      _logger.stderr('cannot find arm64 build folder at: $buildFilesFolderArchitecture');
+    if (architecture == 'arm64' &&
+        !(await Directory(buildFilesFolderArchitecture).exists())) {
+      _logger.stderr(
+          'cannot find arm64 build folder at: $buildFilesFolderArchitecture');
       exit(-1);
     }
 
-    if (await Directory(p.join(buildFilesFolderArchitecture, 'runner')).exists()) {
+    if (await Directory(p.join(buildFilesFolderArchitecture, 'runner'))
+        .exists()) {
       return p.join(buildFilesFolderStart, architecture, buildFilesFolderEnd);
     } else {
       return p.join(buildFilesFolderStart, buildFilesFolderEnd);
@@ -381,8 +449,14 @@ class Configuration {
   Future<void> validateAppInstallerConfigValues() async {
     _logger.trace('validating app installer config values');
 
-    if (publishFolderPath.isNullOrEmpty || (!await Directory(publishFolderPath!).exists() && !await Directory(publishFolderPath = '${Directory.current.path}\\${publishFolderPath!}').exists())) {
-      _logger.stderr('publish folder path is not exists, check "app_installer: publish_folder_path" at pubspec.yaml'.red);
+    if (publishFolderPath.isNullOrEmpty ||
+        (!await Directory(publishFolderPath!).exists() &&
+            !await Directory(publishFolderPath =
+                    '${Directory.current.path}\\${publishFolderPath!}')
+                .exists())) {
+      _logger.stderr(
+          'publish folder path is not exists, check "app_installer: publish_folder_path" at pubspec.yaml'
+              .red);
       exit(-1);
     } else {
       publishFolderPath = Uri.decodeFull(publishFolderPath!);
@@ -409,7 +483,8 @@ class Configuration {
       throw 'Failed to locate msix assets path.';
     }
 
-    String path = '${msixPackage.packageUriRoot.toString().replaceAll('file:///', '')}assets';
+    String path =
+        '${msixPackage.packageUriRoot.toString().replaceAll('file:///', '')}assets';
 
     msixAssetsPath = Uri.decodeFull(path);
   }
@@ -426,21 +501,47 @@ class Configuration {
     if (yaml['version'] == null) return null;
     try {
       final Version pubspecVersion = Version.parse(yaml['version']);
-      return [pubspecVersion.major, pubspecVersion.minor, pubspecVersion.patch, 0].join('.');
+      return [
+        pubspecVersion.major,
+        pubspecVersion.minor,
+        pubspecVersion.patch,
+        0
+      ].join('.');
     } on FormatException {
-      _logger.stderr('Warning: Could not parse Pubspec version. No version provided.');
+      _logger.stderr(
+          'Warning: Could not parse Pubspec version. No version provided.');
       return null;
     }
   }
 
   /// Get the languages list
-  Iterable<String>? _getLanguages(dynamic config) => ((_args['languages'] ?? config['languages']) as String?)?.split(',').map((e) => e.trim()).where((element) => element.isNotEmpty);
+  Iterable<String>? _getLanguages(dynamic config) =>
+      ((_args['languages'] ?? config['languages']) as String?)
+          ?.split(',')
+          .map((e) => e.trim())
+          .where((element) => element.isNotEmpty);
 
   /// Get the app uri handler hosts list
-  Iterable<String>? _getAppUriHandlerHosts(dynamic config) => ((_args['app-uri-handler-hosts'] ?? config['app_uri_handler_hosts']) as String?)?.split(',').map((e) => e.trim()).where((element) => element.isNotEmpty);
+  Iterable<String>? _getAppUriHandlerHosts(dynamic config) =>
+      ((_args['app-uri-handler-hosts'] ?? config['app_uri_handler_hosts'])
+              as String?)
+          ?.split(',')
+          .map((e) => e.trim())
+          .where((element) => element.isNotEmpty);
 
   /// Get the protocol activation list
-  Iterable<String> _getProtocolsActivation(dynamic config) => ((_args['protocol-activation'] ?? config['protocol_activation']) as String?)?.split(',').map((protocol) => protocol.trim().toLowerCase().replaceAll('://', '').replaceAll(':/', '').replaceAll(':', '')).where((protocol) => protocol.isNotEmpty) ?? [];
+  Iterable<String> _getProtocolsActivation(dynamic config) =>
+      ((_args['protocol-activation'] ?? config['protocol_activation'])
+              as String?)
+          ?.split(',')
+          .map((protocol) => protocol
+              .trim()
+              .toLowerCase()
+              .replaceAll('://', '')
+              .replaceAll(':/', '')
+              .replaceAll(':', ''))
+          .where((protocol) => protocol.isNotEmpty) ??
+      [];
 
   Future<String> _getExecutableFileName() async {
     _logger.progress('Searching for executable file name...');
@@ -450,7 +551,8 @@ class Configuration {
       _logger.progress('executable name found from CMake: $executableName');
       return executableName;
     }
-    _logger.progress('executable name not found from CMake, trying pubspec.yaml');
+    _logger
+        .progress('executable name not found from CMake, trying pubspec.yaml');
 
     //Try to obtain executable name from pubspec.yaml (app name)
     executableName = await _getExecutableFromPubspec();
@@ -458,14 +560,18 @@ class Configuration {
       _logger.progress('executable name found from pubspec: $executableName');
       return executableName;
     }
-    _logger.progress('executable name not found from pubspec, trying fallback method');
+    _logger.progress(
+        'executable name not found from pubspec, trying fallback method');
     // Fallback to searching the build files folder
     _logger.progress('using fallback method to find executable');
     // Use the new helper method to find the executable, excluding unwanted exe names
-    executableName = await _findExecutableFileName(exclude: ['PSFLauncher64.exe', 'crashpad_handler.exe']);
-    _logger.progress('executable name found from fallback method: $executableName');
+    executableName = await _findExecutableFileName(
+        exclude: ['PSFLauncher64.exe', 'crashpad_handler.exe']);
+    _logger.progress(
+        'executable name found from fallback method: $executableName');
     if (executableName == null) {
-      _logger.stderr('No executable file found in $buildFilesFolder, first run "flutter build windows" then try again');
+      _logger.stderr(
+          'No executable file found in $buildFilesFolder, first run "flutter build windows" then try again');
       exit(-1);
     } else {
       _logger.progress('executable name: $executableName');
@@ -480,12 +586,17 @@ class Configuration {
 
       if (await cmakeFile.exists()) {
         final content = await cmakeFile.readAsString();
-        final binaryNameMatch = RegExp(r'set\s*\(\s*BINARY_NAME\s+"([^"]+)"\s*\)', caseSensitive: false).firstMatch(content);
+        final binaryNameMatch = RegExp(
+                r'set\s*\(\s*BINARY_NAME\s+"([^"]+)"\s*\)',
+                caseSensitive: false)
+            .firstMatch(content);
         if (binaryNameMatch != null) {
           return '${binaryNameMatch.group(1)}.exe';
         }
 
-        final projectMatch = RegExp(r'project\s*\(\s*([^\s\)]+)', caseSensitive: false).firstMatch(content);
+        final projectMatch =
+            RegExp(r'project\s*\(\s*([^\s\)]+)', caseSensitive: false)
+                .firstMatch(content);
         if (projectMatch != null) {
           String projectName = projectMatch.group(1)!.replaceAll('"', '');
           final expectedExe = '$projectName.exe';
@@ -525,7 +636,8 @@ class Configuration {
     return null;
   }
 
-  Future<String?> _findExecutableFileName({required List<String> exclude}) async {
+  Future<String?> _findExecutableFileName(
+      {required List<String> exclude}) async {
     try {
       final files = await Directory(buildFilesFolder).list().toList();
       for (var file in files) {
@@ -555,9 +667,13 @@ class StartupTask {
   /// This is useful to detect if the app was started automatically.
   final String? parameters;
 
-  StartupTask({required this.taskId, required this.enabled, required this.parameters});
+  StartupTask(
+      {required this.taskId, required this.enabled, required this.parameters});
 
   factory StartupTask.fromMap(Map map, String appName) {
-    return StartupTask(taskId: map['task_id'] ?? appName.replaceAll('_', ''), enabled: map['enabled'] ?? true, parameters: map['parameters']);
+    return StartupTask(
+        taskId: map['task_id'] ?? appName.replaceAll('_', ''),
+        enabled: map['enabled'] ?? true,
+        parameters: map['parameters']);
   }
 }

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -481,8 +481,6 @@ class Configuration {
       if (await cmakeFile.exists()) {
         final content = await cmakeFile.readAsString();
         final binaryNameMatch = RegExp(r'set\s*\(\s*BINARY_NAME\s+"([^"]+)"\s*\)', caseSensitive: false).firstMatch(content);
-        _logger.progress('Searching for executable name in CMakeLists.txt: $binaryNameMatch');
-        _logger.trace('CMakeLists.txt content: $content');
         if (binaryNameMatch != null) {
           return '${binaryNameMatch.group(1)}.exe';
         }

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -311,7 +311,7 @@ class Configuration {
       _logger.stderr('No executable file found in $buildFilesFolder, first run "flutter build windows" then try again');
       exit(-1);
     }
-    _logger.trace('executable file name: $executableFileName');
+    _logger.progress('executable file name: $executableFileName');
   }
 
   /// Declare and parse the cli arguments


### PR DESCRIPTION
@YehudaKremer  hello!
In some scenarios, when compiling our app on Windows with certain packages (for example, Sentry), the package creates an additional executable — such as crashpad_handler.exe — but the name can vary.

In the previous version, the code simply iterated over the list of .exe files and picked the first one found. The issue is that if your app is called Zillion.exe but crashpad_handler.exe appears first (because it starts with "C"), the wrong executable would be included in the XML.

It took me three releases to finally track down this issue.

This PR fixes the problem once and for all with a simple approach:

First, search for the app name in CMakeLists.txt by reading the value from set(BINARY_NAME "myappname").

If not found, read the name field from pubspec.yaml.

If still not found, fall back to the previous behavior and select the first .exe in the list.

In most cases, steps 1 and 2 are enough to correctly determine the executable name.

Feel free to test this fix.
> dart run msix:create
> Building package executable... (2.9s)
> Built msix:create.
> building msix files...
> Searching for executable file name......
> executable name found from CMake: myapp.exe...
> packing msix files...                  3.2s

