### PR TITLE
feat: Add windows_exe_name attribute for specifying the main executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
+## 3.16.11+1
+- add exePathFile
 
 ## 3.16.10
-
 - Update `get_it` version [#306]
 
 ## 3.16.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,4 @@
 # Changelog
-## 3.16.11+1
-- add exePathFile
 
 ## 3.16.10
 - Update `get_it` version [#306]

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -372,7 +372,7 @@ class Configuration {
       throw 'Build files not found at $buildFilesFolder, first run "flutter build windows" then try again';
     }
 
-    executableFileName = exexutableFileName ?? await Directory(buildFilesFolder)
+    executableFileName = executableFileName ?? await Directory(buildFilesFolder)
         .list()
         .firstWhere((file) =>
             file.path.endsWith('.exe') &&

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -23,8 +23,7 @@ class Configuration {
   String? identityName;
   String? msixVersion;
   String? appDescription;
-  String buildFilesFolder =
-      p.join(Directory.current.path, 'build', 'windows', 'runner', 'Release');
+  String buildFilesFolder = p.join(Directory.current.path, 'build', 'windows', 'runner', 'Release');
   String? certificatePath;
   String? certificatePassword;
   String? publisher;
@@ -60,12 +59,9 @@ class Configuration {
   Iterable<String>? appUriHandlerHosts;
   Iterable<String>? languages;
   String get defaultsIconsFolderPath => p.join(msixAssetsPath, 'icons');
-  String get msixToolkitPath =>
-      p.join(msixAssetsPath, 'MSIX-Toolkit', 'Redist.x64');
-  String get msixPath =>
-      p.join(outputPath ?? buildFilesFolder, '${outputName ?? appName}.msix');
-  String get appInstallerPath => p.join(publishFolderPath!,
-      basename(msixPath).replaceAll('.msix', '.appinstaller'));
+  String get msixToolkitPath => p.join(msixAssetsPath, 'MSIX-Toolkit', 'Redist.x64');
+  String get msixPath => p.join(outputPath ?? buildFilesFolder, '${outputName ?? appName}.msix');
+  String get appInstallerPath => p.join(publishFolderPath!, basename(msixPath).replaceAll('.msix', '.appinstaller'));
   String pubspecYamlPath = "pubspec.yaml";
   String osMinVersion = '10.0.17763.0';
   bool isTestCertificate = false;
@@ -81,60 +77,42 @@ class Configuration {
     appName = pubspec['name'];
     appDescription = pubspec['description'];
     dynamic yaml = pubspec['msix_config'] ?? YamlMap();
-    msixVersion =
-        _args['version'] ?? yaml['msix_version'] ?? _getPubspecVersion(pubspec);
+    msixVersion = _args['version'] ?? yaml['msix_version'] ?? _getPubspecVersion(pubspec);
     certificatePath = _args['certificate-path'] ?? yaml['certificate_path'];
-    certificatePassword = _args['certificate-password'] ??
-        yaml['certificate_password']?.toString();
+    certificatePassword = _args['certificate-password'] ?? yaml['certificate_password']?.toString();
     outputPath = _args['output-path'] ?? yaml['output_path'];
     outputName = _args['output-name'] ?? yaml['output_name'];
     executionAlias = _args['execution-alias'] ?? yaml['execution_alias'];
-    if (_args['sign-msix'].toString() == 'false' ||
-        yaml['sign_msix']?.toString().toLowerCase() == 'false') {
+    if (_args['sign-msix'].toString() == 'false' || yaml['sign_msix']?.toString().toLowerCase() == 'false') {
       signMsix = false;
     }
-    if (_args['install-certificate'].toString() == 'false' ||
-        yaml['install_certificate']?.toString().toLowerCase() == 'false') {
+    if (_args['install-certificate'].toString() == 'false' || yaml['install_certificate']?.toString().toLowerCase() == 'false') {
       installCert = false;
     }
-    if (_args['build-windows'].toString() == 'false' ||
-        yaml['build_windows']?.toString().toLowerCase() == 'false') {
+    if (_args['build-windows'].toString() == 'false' || yaml['build_windows']?.toString().toLowerCase() == 'false') {
       buildWindows = false;
     }
-    if (_args['trim-logo'].toString() == 'false' ||
-        yaml['trim_logo']?.toString().toLowerCase() == 'false') {
+    if (_args['trim-logo'].toString() == 'false' || yaml['trim_logo']?.toString().toLowerCase() == 'false') {
       trimLogo = false;
     }
-    store = _args.wasParsed('store') ||
-        yaml['store']?.toString().toLowerCase() == 'true';
-    createWithDebugBuildFiles = _args.wasParsed('debug') ||
-        yaml['debug']?.toString().toLowerCase() == 'true';
+    store = _args.wasParsed('store') || yaml['store']?.toString().toLowerCase() == 'true';
+    createWithDebugBuildFiles = _args.wasParsed('debug') || yaml['debug']?.toString().toLowerCase() == 'true';
 
     displayName = _args['display-name'] ?? yaml['display_name'];
-    publisherName =
-        _args['publisher-display-name'] ?? yaml['publisher_display_name'];
+    publisherName = _args['publisher-display-name'] ?? yaml['publisher_display_name'];
     publisher = _args['publisher'] ?? yaml['publisher'];
     identityName = _args['identity-name'] ?? yaml['identity_name'];
     logoPath = _args['logo-path'] ?? yaml['logo_path'];
-    osMinVersion =
-        _args['os-min-version'] ?? yaml['os_min_version'] ?? osMinVersion;
+    osMinVersion = _args['os-min-version'] ?? yaml['os_min_version'] ?? osMinVersion;
+    executableFileName = yaml['exeFilePath'] ?? null;
 
-    final String? signToolOptionsConfig =
-        (_args['signtool-options'] ?? yaml['signtool_options'])?.toString();
+    final String? signToolOptionsConfig = (_args['signtool-options'] ?? yaml['signtool_options'])?.toString();
     if (signToolOptionsConfig != null && signToolOptionsConfig.isNotEmpty) {
       CommandLineConverter commandLineConverter = CommandLineConverter();
       signToolOptions = commandLineConverter.convert(signToolOptionsConfig);
     }
 
-    final String? exePath =
-        (_args['executable-file-path'] ?? yaml['executable_file_path'])?.toString();
-    if (exePath != null && exePath.isNotEmpty) {
-      CommandLineConverter commandLineConverter = CommandLineConverter();
-      executableFileName = commandLineConverter.convert(signToolOptionsConfig);
-    }
-
-    final String? windowsBuildArgsConfig =
-        (_args['windows-build-args'] ?? yaml['windows_build_args'])?.toString();
+    final String? windowsBuildArgsConfig = (_args['windows-build-args'] ?? yaml['windows_build_args'])?.toString();
     if (windowsBuildArgsConfig != null && windowsBuildArgsConfig.isNotEmpty) {
       CommandLineConverter commandLineConverter = CommandLineConverter();
       windowsBuildArgs = commandLineConverter.convert(windowsBuildArgsConfig);
@@ -150,60 +128,35 @@ class Configuration {
     capabilities = _args['capabilities'] ?? yaml['capabilities'];
     languages = _getLanguages(yaml);
     appUriHandlerHosts = _getAppUriHandlerHosts(yaml);
-    enableAtStartup = _args.wasParsed('enable-at-startup') ||
-        yaml['enable_at_startup']?.toString().toLowerCase() == 'true';
+    enableAtStartup = _args.wasParsed('enable-at-startup') || yaml['enable_at_startup']?.toString().toLowerCase() == 'true';
 
     // A more advanced version of 'enable_at_startup'
-    startupTask = yaml['startup_task'] != null
-        ? StartupTask.fromMap(yaml['startup_task'], appName!)
-        : null;
+    startupTask = yaml['startup_task'] != null ? StartupTask.fromMap(yaml['startup_task'], appName!) : null;
 
     // toast activator configurations
     dynamic toastActivatorYaml = yaml['toast_activator'] ?? YamlMap();
 
-    toastActivatorCLSID = _args['toast-activator-clsid'] ??
-        toastActivatorYaml['clsid']?.toString();
-    toastActivatorArguments = _args['toast-activator-arguments'] ??
-        toastActivatorYaml['arguments']?.toString() ??
-        '----AppNotificationActivationServer';
-    toastActivatorDisplayName = _args['toast-activator-display-name'] ??
-        toastActivatorYaml['display_name']?.toString() ??
-        'Toast activator';
+    toastActivatorCLSID = _args['toast-activator-clsid'] ?? toastActivatorYaml['clsid']?.toString();
+    toastActivatorArguments = _args['toast-activator-arguments'] ?? toastActivatorYaml['arguments']?.toString() ?? '----AppNotificationActivationServer';
+    toastActivatorDisplayName = _args['toast-activator-display-name'] ?? toastActivatorYaml['display_name']?.toString() ?? 'Toast activator';
 
     // app installer configurations
     dynamic installerYaml = yaml['app_installer'] ?? YamlMap();
 
-    publishFolderPath =
-        _args['publish-folder-path'] ?? installerYaml['publish_folder_path'];
-    hoursBetweenUpdateChecks = int.parse(_args['hours-between-update-checks'] ??
-        installerYaml['hours_between_update_checks']?.toString() ??
-        '0');
+    publishFolderPath = _args['publish-folder-path'] ?? installerYaml['publish_folder_path'];
+    hoursBetweenUpdateChecks = int.parse(_args['hours-between-update-checks'] ?? installerYaml['hours_between_update_checks']?.toString() ?? '0');
     if (hoursBetweenUpdateChecks < 0) hoursBetweenUpdateChecks = 0;
-    automaticBackgroundTask = _args.wasParsed('automatic-background-task') ||
-        installerYaml['automatic_background_task']?.toString().toLowerCase() ==
-            'true';
-    updateBlocksActivation = _args.wasParsed('update-blocks-activation') ||
-        installerYaml['update_blocks_activation']?.toString().toLowerCase() ==
-            'true';
-    showPrompt = _args.wasParsed('show-prompt') ||
-        installerYaml['show_prompt']?.toString().toLowerCase() == 'true';
-    forceUpdateFromAnyVersion =
-        _args.wasParsed('force-update-from-any-version') ||
-            installerYaml['force_update_from_any_version']
-                    ?.toString()
-                    .toLowerCase() ==
-                'true';
+    automaticBackgroundTask = _args.wasParsed('automatic-background-task') || installerYaml['automatic_background_task']?.toString().toLowerCase() == 'true';
+    updateBlocksActivation = _args.wasParsed('update-blocks-activation') || installerYaml['update_blocks_activation']?.toString().toLowerCase() == 'true';
+    showPrompt = _args.wasParsed('show-prompt') || installerYaml['show_prompt']?.toString().toLowerCase() == 'true';
+    forceUpdateFromAnyVersion = _args.wasParsed('force-update-from-any-version') || installerYaml['force_update_from_any_version']?.toString().toLowerCase() == 'true';
 
     // context menu configurations
     dynamic contextMenuYaml = yaml['context_menu'];
 
     bool skipContextMenu = _args.wasParsed('skip-context-menu');
 
-    contextMenuConfiguration = contextMenuYaml != null &&
-            contextMenuYaml is YamlMap &&
-            !skipContextMenu
-        ? ContextMenuConfiguration.fromYaml(contextMenuYaml)
-        : null;
+    contextMenuConfiguration = contextMenuYaml != null && contextMenuYaml is YamlMap && !skipContextMenu ? ContextMenuConfiguration.fromYaml(contextMenuYaml) : null;
   }
 
   /// Validate the configuration values and set default values
@@ -218,8 +171,7 @@ class Configuration {
     if (displayName.isNull) displayName = cleanAppName;
     if (identityName.isNull) {
       if (store) {
-        _logger.stderr(
-            'identity name is empty, check "msix_config: identity_name" at pubspec.yaml');
+        _logger.stderr('identity name is empty, check "msix_config: identity_name" at pubspec.yaml');
         throw 'you can find your store "identity_name" in https://partner.microsoft.com/en-us/dashboard > Product > Product identity > Package/Identity/Name';
       } else {
         identityName = 'com.flutter.$cleanAppName';
@@ -231,21 +183,18 @@ class Configuration {
     }
     if (publisherName.isNull) {
       if (store) {
-        _logger.stderr(
-            'publisher display name is empty, check "msix_config: publisher_display_name" at pubspec.yaml');
+        _logger.stderr('publisher display name is empty, check "msix_config: publisher_display_name" at pubspec.yaml');
         throw 'you can find your store "publisher_display_name" in https://partner.microsoft.com/en-us/dashboard > Product > Product identity > Package/Properties/PublisherDisplayName';
       } else {
         publisherName = identityName;
       }
     }
     if (signMsix == false && publisher.isNullOrEmpty) {
-      _logger.stderr(
-          'when sign_msix is false, you must provide the publisher value at "msix_config: publisher" in the pubspec.yaml file');
+      _logger.stderr('when sign_msix is false, you must provide the publisher value at "msix_config: publisher" in the pubspec.yaml file');
       exit(-1);
     }
     if (store && publisher.isNullOrEmpty) {
-      _logger.stderr(
-          'publisher is empty, check "msix_config: publisher" at pubspec.yaml');
+      _logger.stderr('publisher is empty, check "msix_config: publisher" at pubspec.yaml');
       throw 'you can find your store "publisher" in https://partner.microsoft.com/en-us/dashboard > Product > Product identity > Package/Properties/Publisher';
     }
     if (msixVersion.isNull) msixVersion = '1.0.0.0';
@@ -272,16 +221,13 @@ class Configuration {
       throw '"publisher display name" is too long, it should be less than 256 characters';
     }
 
-    if (!certificatePath.isNull ||
-        (SignTool.isCustomSignCommand(signToolOptions)) ||
-        store) {
+    if (!certificatePath.isNull || (SignTool.isCustomSignCommand(signToolOptions)) || store) {
       if (!certificatePath.isNull) {
         if (!(await File(certificatePath!).exists())) {
           throw 'The file certificate not found in: $certificatePath, check "msix_config: certificate_path" at pubspec.yaml';
         }
 
-        if (extension(certificatePath!).toLowerCase() == '.pfx' &&
-            certificatePassword.isNull) {
+        if (extension(certificatePath!).toLowerCase() == '.pfx' && certificatePassword.isNull) {
           throw 'Certificate password is empty, check "msix_config: certificate_password" at pubspec.yaml';
         }
       }
@@ -314,10 +260,7 @@ class Configuration {
           throw 'Context menu item commands is empty';
         }
 
-        if (contextMenuConfiguration!.items
-                .where((element) => element.type == item.type)
-                .length >
-            1) {
+        if (contextMenuConfiguration!.items.where((element) => element.type == item.type).length > 1) {
           throw 'Found same context menu item type more than once, type must be unique for each item. Type: ${item.type}';
         }
 
@@ -330,8 +273,7 @@ class Configuration {
             throw 'Context menu command clsid is empty';
           }
 
-          if (command.customDllPath != null &&
-              !await File(command.customDllPath!).exists()) {
+          if (command.customDllPath != null && !await File(command.customDllPath!).exists()) {
             throw 'The context menu command custom dll file not found in: ${command.customDllPath}, check "msix_config: context_menu: items: commands: custom_dll" at pubspec.yaml';
           }
 
@@ -339,18 +281,12 @@ class Configuration {
             throw 'Context menu command clsid cannot be the same as toast activator clsid, Clsid: ${command.clsid}';
           }
 
-          if (item.commands
-                  .where((element) => element.clsid == command.clsid)
-                  .length >
-              1) {
+          if (item.commands.where((element) => element.clsid == command.clsid).length > 1) {
             throw 'Found same context menu command more than once in same type. Clsid: ${command.clsid}, Type: ${item.type}';
           }
 
-          for (List<ContextMenuItemCommand> command2
-              in contextMenuConfiguration!.items.map((e) => e.commands)) {
-            if (command2.any((element) =>
-                element.clsid == command.clsid &&
-                element.customDllPath != command.customDllPath)) {
+          for (List<ContextMenuItemCommand> command2 in contextMenuConfiguration!.items.map((e) => e.commands)) {
+            if (command2.any((element) => element.clsid == command.clsid && element.customDllPath != command.customDllPath)) {
               throw 'Context menu command clsid must be unique for each class, but found duplicate.\nClsid: ${command.clsid} with different dll path: ${command.customDllPath ?? contextMenuConfiguration!.dllPath} and ${command2.firstWhere((element) => element.id == command.id).customDllPath}';
             }
           }
@@ -365,19 +301,11 @@ class Configuration {
 
     _logger.trace('validating build files');
 
-    if (!await Directory(buildFilesFolder).exists() ||
-        !await Directory(buildFilesFolder)
-            .list()
-            .any((file) => file.path.endsWith('.exe'))) {
+    if (!await Directory(buildFilesFolder).exists() || !await Directory(buildFilesFolder).list().any((file) => file.path.endsWith('.exe'))) {
       throw 'Build files not found at $buildFilesFolder, first run "flutter build windows" then try again';
     }
 
-    executableFileName = executableFileName ?? await Directory(buildFilesFolder)
-        .list()
-        .firstWhere((file) =>
-            file.path.endsWith('.exe') &&
-            !file.path.contains('PSFLauncher64.exe'))
-        .then((file) => basename(file.path));
+    executableFileName = executableFileName ?? await Directory(buildFilesFolder).list().firstWhere((file) => file.path.endsWith('.exe') && !file.path.contains('PSFLauncher64.exe')).then((file) => basename(file.path));
   }
 
   /// Declare and parse the cli arguments
@@ -429,22 +357,16 @@ class Configuration {
   }
 
   Future<String> _updateBuildFilesFolder() async {
-    final String buildFilesFolderStart =
-        buildFilesFolder.substring(0, buildFilesFolder.lastIndexOf('runner'));
-    final String buildFilesFolderArchitecture =
-        p.join(buildFilesFolderStart, architecture);
-    final String buildFilesFolderEnd =
-        buildFilesFolder.substring(buildFilesFolder.lastIndexOf('runner'));
+    final String buildFilesFolderStart = buildFilesFolder.substring(0, buildFilesFolder.lastIndexOf('runner'));
+    final String buildFilesFolderArchitecture = p.join(buildFilesFolderStart, architecture);
+    final String buildFilesFolderEnd = buildFilesFolder.substring(buildFilesFolder.lastIndexOf('runner'));
 
-    if (architecture == 'arm64' &&
-        !(await Directory(buildFilesFolderArchitecture).exists())) {
-      _logger.stderr(
-          'cannot find arm64 build folder at: $buildFilesFolderArchitecture');
+    if (architecture == 'arm64' && !(await Directory(buildFilesFolderArchitecture).exists())) {
+      _logger.stderr('cannot find arm64 build folder at: $buildFilesFolderArchitecture');
       exit(-1);
     }
 
-    if (await Directory(p.join(buildFilesFolderArchitecture, 'runner'))
-        .exists()) {
+    if (await Directory(p.join(buildFilesFolderArchitecture, 'runner')).exists()) {
       return p.join(buildFilesFolderStart, architecture, buildFilesFolderEnd);
     } else {
       return p.join(buildFilesFolderStart, buildFilesFolderEnd);
@@ -454,14 +376,8 @@ class Configuration {
   Future<void> validateAppInstallerConfigValues() async {
     _logger.trace('validating app installer config values');
 
-    if (publishFolderPath.isNullOrEmpty ||
-        (!await Directory(publishFolderPath!).exists() &&
-            !await Directory(publishFolderPath =
-                    '${Directory.current.path}\\${publishFolderPath!}')
-                .exists())) {
-      _logger.stderr(
-          'publish folder path is not exists, check "app_installer: publish_folder_path" at pubspec.yaml'
-              .red);
+    if (publishFolderPath.isNullOrEmpty || (!await Directory(publishFolderPath!).exists() && !await Directory(publishFolderPath = '${Directory.current.path}\\${publishFolderPath!}').exists())) {
+      _logger.stderr('publish folder path is not exists, check "app_installer: publish_folder_path" at pubspec.yaml'.red);
       exit(-1);
     } else {
       publishFolderPath = Uri.decodeFull(publishFolderPath!);
@@ -488,8 +404,7 @@ class Configuration {
       throw 'Failed to locate msix assets path.';
     }
 
-    String path =
-        '${msixPackage.packageUriRoot.toString().replaceAll('file:///', '')}assets';
+    String path = '${msixPackage.packageUriRoot.toString().replaceAll('file:///', '')}assets';
 
     msixAssetsPath = Uri.decodeFull(path);
   }
@@ -506,12 +421,7 @@ class Configuration {
     if (yaml['version'] == null) return null;
     try {
       final Version pubspecVersion = Version.parse(yaml['version']);
-      return [
-        pubspecVersion.major,
-        pubspecVersion.minor,
-        pubspecVersion.patch,
-        0
-      ].join('.');
+      return [pubspecVersion.major, pubspecVersion.minor, pubspecVersion.patch, 0].join('.');
     } on FormatException {
       _logger.stderr(
         'Warning: Could not parse Pubspec version. No version provided.',
@@ -521,33 +431,15 @@ class Configuration {
   }
 
   /// Get the languages list
-  Iterable<String>? _getLanguages(dynamic config) =>
-      ((_args['languages'] ?? config['languages']) as String?)
-          ?.split(',')
-          .map((e) => e.trim())
-          .where((element) => element.isNotEmpty);
+  Iterable<String>? _getLanguages(dynamic config) => ((_args['languages'] ?? config['languages']) as String?)?.split(',').map((e) => e.trim()).where((element) => element.isNotEmpty);
 
   /// Get the app uri handler hosts list
-  Iterable<String>? _getAppUriHandlerHosts(dynamic config) =>
-      ((_args['app-uri-handler-hosts'] ?? config['app_uri_handler_hosts'])
-              as String?)
-          ?.split(',')
-          .map((e) => e.trim())
-          .where((element) => element.isNotEmpty);
+  Iterable<String>? _getAppUriHandlerHosts(dynamic config) => ((_args['app-uri-handler-hosts'] ?? config['app_uri_handler_hosts']) as String?)?.split(',').map((e) => e.trim()).where((element) => element.isNotEmpty);
 
   /// Get the protocol activation list
   Iterable<String> _getProtocolsActivation(dynamic config) =>
-      ((_args['protocol-activation'] ?? config['protocol_activation'])
-              as String?)
-          ?.split(',')
-          .map((protocol) => protocol
-              .trim()
-              .toLowerCase()
-              .replaceAll('://', '')
-              .replaceAll(':/', '')
-              .replaceAll(':', ''))
-          .where((protocol) => protocol.isNotEmpty) ??
-      [];
+      ((_args['protocol-activation'] ?? config['protocol_activation']) as String?)?.split(',').map((protocol) => protocol.trim().toLowerCase().replaceAll('://', '').replaceAll(':/', '').replaceAll(':', '')).where((protocol) => protocol.isNotEmpty) ??
+          [];
 }
 
 /// A more advanced version of 'enable_at_startup'.

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -365,6 +365,8 @@ class Configuration {
       throw 'Build files not found at $buildFilesFolder, first run "flutter build windows" then try again';
     }
 
+    dynamic installerYaml = yaml['app_installer'] ?? YamlMap();
+
     executableFileName = installerYaml['executable_file'] ?? await Directory(buildFilesFolder)
         .list()
         .firstWhere((file) =>

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -126,6 +126,13 @@ class Configuration {
       signToolOptions = commandLineConverter.convert(signToolOptionsConfig);
     }
 
+    final String? exePath =
+        (_args['executable-file-path'] ?? yaml['executable_file_path'])?.toString();
+    if (exePath != null && exePath.isNotEmpty) {
+      CommandLineConverter commandLineConverter = CommandLineConverter();
+      executableFileName = commandLineConverter.convert(signToolOptionsConfig);
+    }
+
     final String? windowsBuildArgsConfig =
         (_args['windows-build-args'] ?? yaml['windows_build_args'])?.toString();
     if (windowsBuildArgsConfig != null && windowsBuildArgsConfig.isNotEmpty) {
@@ -365,9 +372,7 @@ class Configuration {
       throw 'Build files not found at $buildFilesFolder, first run "flutter build windows" then try again';
     }
 
-    dynamic installerYaml = yaml['app_installer'] ?? YamlMap();
-
-    executableFileName = installerYaml['executable_file'] ?? await Directory(buildFilesFolder)
+    executableFileName = exexutableFileName ?? await Directory(buildFilesFolder)
         .list()
         .firstWhere((file) =>
             file.path.endsWith('.exe') &&

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -365,7 +365,7 @@ class Configuration {
       throw 'Build files not found at $buildFilesFolder, first run "flutter build windows" then try again';
     }
 
-    executableFileName = await Directory(buildFilesFolder)
+    executableFileName = installerYaml['executable_file'] ?? await Directory(buildFilesFolder)
         .list()
         .firstWhere((file) =>
             file.path.endsWith('.exe') &&

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -104,7 +104,7 @@ class Configuration {
     identityName = _args['identity-name'] ?? yaml['identity_name'];
     logoPath = _args['logo-path'] ?? yaml['logo_path'];
     osMinVersion = _args['os-min-version'] ?? yaml['os_min_version'] ?? osMinVersion;
-    executableFileName = yaml['exeFilePath'] ?? null;
+    executableFileName = yaml['exeFileName'] ?? null;
 
     final String? signToolOptionsConfig = (_args['signtool-options'] ?? yaml['signtool_options'])?.toString();
     if (signToolOptionsConfig != null && signToolOptionsConfig.isNotEmpty) {


### PR DESCRIPTION
This pull request introduces an optional exeFileName attribute to the pubspec.yaml file.

### The Problem
When building a Flutter or similar project for Windows, the build process can sometimes generate multiple executable (.exe) files in the output directory. This can cause issues for third-party installer tools. which may incorrectly identify a secondary executable as the main application launcher. This leads to a poor user experience, as the shortcut created by the installer may launch the wrong file.

### The Solution
By adding the exeFileName attribute, developers can explicitly specify the filename of their application's main executable. The build process can then use this value to ensure the correct file is used as the primary launcher.