### PR TITLE
chore(deps): update get_it from ^8.0.3 to ^9.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   yaml: ^3.1.0
   path: ^1.8.0
   package_config: ^2.1.0
-  get_it: ^8.0.3
+  get_it: ^9.1.0
   image: ^4.0.9
   pub_semver: ^2.1.0
   console: ^4.1.0


### PR DESCRIPTION
## Summary

Updates the `get_it` dependency constraint from `^8.0.3` to `^9.1.0`.

## Why

The current `get_it ^8.0.3` constraint causes dependency conflicts with packages that require `get_it ^9.x`, such as `dart_pre_commit >=6.1.0`.

### Example conflict

```
Because msix ^3.16.12 depends on get_it ^8.0.3 and dart_pre_commit >=6.1.0 depends on get_it ^9.1.0, 
msix ^3.16.12 is incompatible with dart_pre_commit >=6.1.0.
```

## Related

- Fixes #319
- Related to #285