### PR TITLE
chore: add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Summary

Adds Dependabot configuration to automatically keep pub dependencies up-to-date.

## Configuration

```yaml
version: 2
updates:
  - package-ecosystem: "pub"
    directory: "/"
    schedule:
      interval: "weekly"
    open-pull-requests-limit: 10
    labels:
      - "dependencies"
```

## Benefits

- **Automated PRs**: Dependabot will create PRs for dependency updates weekly
- **Security alerts**: Get notified of security vulnerabilities in dependencies  
- **Reduced maintenance**: Less manual work tracking outdated dependencies
- **Ecosystem compatibility**: Keeps the package compatible with the broader Dart/Flutter ecosystem

## Why this matters

Issues like #319, #285 (outdated `get_it` constraint) could be avoided with automated dependency updates. Dependabot would have created a PR when `get_it` 9.x was released.

## Related

- Fixes #321